### PR TITLE
Workflow hydration

### DIFF
--- a/queenbee/cli.py
+++ b/queenbee/cli.py
@@ -110,7 +110,7 @@ def viz():
                                        .' '.            __
   viiiiiiiiiiiiizzzzzzzzz!  . .        .   .           (__\_
                                .         .         . -{{_(|8)
-                                ' .  . ' ' .  . '     (__/
+                                 ' .  . ' ' .  . '     (__/
 
     """)
 
@@ -119,6 +119,7 @@ def viz():
 @click.option('-d', '--display', help='boolean flag to display the workflow in your browser', default=False, type=bool, is_flag=True)
 @click.pass_context
 def validate(ctx, file, display):
+    """Validate an existing workflow file"""
     wf = ctx.obj.parse_workflow(file)
 
     dot = wf.to_diagraph(filename=file.split('.')[0])

--- a/queenbee/cli.py
+++ b/queenbee/cli.py
@@ -71,6 +71,7 @@ from queenbee.schema.workflow import Workflow
 # import logging
 # logger = logging.getLogger(__name__)
 
+
 class Context():
 
     @staticmethod
@@ -100,7 +101,7 @@ def main(ctx):
 
     """
     ctx.obj = Context()
-    
+
 
 @main.command('viz')
 def viz():
@@ -113,6 +114,7 @@ def viz():
                                  ' .  . ' ' .  . '     (__/
 
     """)
+
 
 @main.command('validate')
 @click.option('-f', '--file', help='path to the workflow file to validate', required=True)
@@ -137,6 +139,7 @@ Valid Workflow!        <\\\\
         query = urllib.parse.quote(dot.pipe(format='xdot'))
         url = 'https://dreampuf.github.io/GraphvizOnline/#{}'.format(query)
         webbrowser.open(url)
+
 
 if __name__ == "__main__":
     main()

--- a/queenbee/schema/arguments.py
+++ b/queenbee/schema/arguments.py
@@ -86,7 +86,7 @@ class Artifact(BaseModel):
 
 class Arguments(BaseModel):
     """Arguments to a task or a workflow.
-    
+
     Queenbee accepts two types of arguments: parameters and artifacts. A ``parameter``
     is a variable that can be passed to a task or a workflow. An ``artifact`` is a file
     or folder that can be identified by a url or a path.

--- a/queenbee/schema/artifact_location.py
+++ b/queenbee/schema/artifact_location.py
@@ -13,6 +13,7 @@ from pydantic import Field, constr
 from typing import Dict
 from enum import Enum
 
+
 class VerbEnum(str, Enum):
     get = 'GET'
     post = 'POST'
@@ -20,9 +21,10 @@ class VerbEnum(str, Enum):
     patch = 'PATCH'
     delete = 'DELETE'
 
+
 class ArtifactLocation(BaseModel):
     """ArtifactLocation
-    
+
     An Artifact Location System
     """
 
@@ -33,12 +35,13 @@ class ArtifactLocation(BaseModel):
 
     root: str = Field(
         ...,
-        description="The root path to the artifacts."   
+        description="The root path to the artifacts."
     )
+
 
 class LocalLocation(BaseModel):
     """Local Location
-    
+
     A folder on a machine's file system. This machine is the one where the workflow is running.
     """
     type: constr(regex='^local$')
@@ -53,19 +56,19 @@ class LocalLocation(BaseModel):
         description="For a local filesystem this can be \"C:\\Users\\me\\simulations\\test\"."
     )
 
+
 class HTTPLocation(BaseModel):
     """HTTPLocation
-    
+
     A web HTTP to an FTP server or an API for example.
     """
-    
+
     type: constr(regex='^http$')
 
     name: str = Field(
         ...,
         description='Name is a unique identifier for this particular Artifact Location'
     )
-
 
     root: str = Field(
         ...,
@@ -83,14 +86,15 @@ class HTTPLocation(BaseModel):
     )
 
     class Config:
-        use_enum_value=True
+        use_enum_value = True
+
 
 class S3Location(BaseModel):
     """S3Location
 
     An S3 bucket
     """
-    
+
     type: constr(regex='^s3$')
 
     name: str = Field(

--- a/queenbee/schema/dag.py
+++ b/queenbee/schema/dag.py
@@ -31,7 +31,7 @@ class LoopControl(BaseModel):
     parallel: bool = Field(
         True,
         description='A switch to indicate if loops should be executed in serial or'
-            ' parallel.'
+        ' parallel.'
     )
 
 
@@ -89,9 +89,9 @@ class DAG(BaseModel):
     target: str = Field(
         None,
         description='Target are one or more names of target tasks to execute in a DAG. '
-            'Multiple targets can be specified as space delimited inputs. When a target '
-            'is provided only a subset of tasks in DAG that are required to generate '
-            'the target(s) will be executed.'
+        'Multiple targets can be specified as space delimited inputs. When a target '
+        'is provided only a subset of tasks in DAG that are required to generate '
+        'the target(s) will be executed.'
     )
 
     fail_fast: bool = Field(

--- a/queenbee/schema/function.py
+++ b/queenbee/schema/function.py
@@ -34,9 +34,9 @@ class Function(BaseModel):
     command: str = Field(
         ...,
         description=u'Full shell command for this function. Each function accepts only '
-            'one command. The command will be executed as a shell command in operator. '
-            'For running several commands after each other use && between the commands '
-            'or pipe data from one to another using |'
+        'one command. The command will be executed as a shell command in operator. '
+        'For running several commands after each other use && between the commands '
+        'or pipe data from one to another using |'
     )
 
     operator: str = Field(
@@ -57,7 +57,7 @@ class Function(BaseModel):
     @validator('inputs')
     def check_workflow_reference(cls, v):
         input_params = v.parameters
-        
+
         if input_params == None:
             return v
 
@@ -69,7 +69,8 @@ class Function(BaseModel):
             if 'workflow.' in param.value:
                 ref_params.append(param)
         if len(ref_params) > 0:
-            params = ['{}: {}'.format(param.name, param.value) for param in ref_params]
+            params = ['{}: {}'.format(param.name, param.value)
+                      for param in ref_params]
             warnings.warn(
                 'Referencing workflow parameters in a template function makes the'
                 ' function less reusable. Try using inputs / outputs of the function'
@@ -101,7 +102,7 @@ class Function(BaseModel):
 
         if v == None:
             return values
-        
+
         output_paths = []
         output_values = []
 
@@ -144,11 +145,10 @@ class Function(BaseModel):
 
         return values
 
-
     @staticmethod
     def validate_variable(variables, func_name, input_names):
         """Validate referenced variables.
-        
+
         Referenced variables must follow x.y.z pattern and start with inputs, outputs or
         workflow (e.g. inputs.parameters.filename).
 
@@ -159,7 +159,8 @@ class Function(BaseModel):
                 ref, typ, name = m.split('.')
             except ValueError:
                 raise ValueError(
-                    '{{%s}} in %s function does not follow x.y.z pattern'% (m, func_name)
+                    '{{%s}} in %s function does not follow x.y.z pattern' % (
+                        m, func_name)
                 )
 
             if not ref in ('inputs', 'outputs', 'workflow'):
@@ -174,11 +175,12 @@ class Function(BaseModel):
                     ' this function. Reference: {}'.format(func_name, m)
                 )
                 continue
-            
+
             # now ensure input references are valid
             if ref != 'inputs' or typ != 'parameters':
                 continue
 
             assert name in input_names, \
                 'Illegal output parameter name in "%s": {{%s}}\n' \
-                'Valid inputs:\n\t- %s' % (func_name, m, '\n\t- '.join(input_names))
+                'Valid inputs:\n\t- %s' % (func_name,
+                                           m, '\n\t- '.join(input_names))

--- a/queenbee/schema/function.py
+++ b/queenbee/schema/function.py
@@ -1,7 +1,7 @@
 """Queenbee Function class."""
 from queenbee.schema.qutil import BaseModel
 from queenbee.schema.parser import parse_double_quotes_vars as var_parser
-from pydantic import Field, validator, root_validator
+from pydantic import Field, validator, root_validator, constr
 from typing import List, Dict
 from enum import Enum
 from queenbee.schema.arguments import Arguments
@@ -11,7 +11,7 @@ import re
 
 class Function(BaseModel):
     """A function with a single command."""
-    type: Enum('function', {'type': 'function'}) = 'function'
+    type: constr(regex='^function$')
 
     name: str = Field(
         ...,

--- a/queenbee/schema/operator.py
+++ b/queenbee/schema/operator.py
@@ -3,7 +3,7 @@
 A task operator includes the information for executing tasks locally or in a container.
 """
 from queenbee.schema.qutil import BaseModel
-from pydantic import Field, validator
+from pydantic import Field, validator, constr
 from typing import List, Any, Set
 from enum import Enum
 
@@ -66,7 +66,7 @@ class Package(BaseModel):
 
 class LocalRequirements(BaseModel):
     """Operator requirements for local runs."""
-    type: Enum('Operator', {'type': 'Operator'}) = 'Operator'
+    type: constr(regex='^operator$') = 'operator'
 
     _valid_platforms: Set[str] = set(['linux', 'windows', 'mac'])
 
@@ -125,7 +125,7 @@ class Operator(BaseModel):
     A task operator includes the information for executing tasks from command line
     or in a container.
     """
-    type: Enum('Operator', {'type': 'Operator'}) = 'Operator'
+    type: constr(regex='^operator$') = 'operator'
 
     name: str = Field(
         ...,

--- a/queenbee/schema/operator.py
+++ b/queenbee/schema/operator.py
@@ -14,12 +14,12 @@ class Language(BaseModel):
         'python',
         description='Language name'
     )
-    
+
     version: str = Field(
         None,
         description='Language version requirements. For instance ==3.7 or >=3.6'
     )
-    
+
     _valid_languages: Set[str] = set(['python', 'nodejs', 'bash'])
 
     # NOTE: yaml conversion doesn't play well with Enum. Use validators like this
@@ -29,7 +29,7 @@ class Language(BaseModel):
         assert v.lower() in cls._valid_languages, \
             '{} is not a valid language. Try one of these languages:\n - {}'.format(
                 v, '\n - '.join(cls._valid_languages)
-            )
+        )
         return v.lower()
 
 
@@ -73,38 +73,38 @@ class LocalRequirements(BaseModel):
     platform: List[str] = Field(
         ['linux', 'windows', 'mac'],
         description='List of valid platforms that operator can execute the commands.'
-        )
+    )
 
     language: List[Language] = Field(
         'bash',
         description='List of required programming languages to execute the commands'
-            ' with an operator.'
-        )
+        ' with an operator.'
+    )
 
     # TODO: expand this to accept command to get the version and also add regex to parse
     # version from stdout
     app: List[App] = Field(
         None,
         description='List of applications that are required for operator to '
-            'execute the commands locally. You must follow pip requirement specifiers: '
-            'https://pip.pypa.io/en/stable/reference/pip_install/#requirement-specifiers'
-            ' For instance use rtrace>=5.2 for radiance 5.2 or newer. Command will run '
-            ' rtrace --version and tries to parse version from command.'
-        )
+        'execute the commands locally. You must follow pip requirement specifiers: '
+        'https://pip.pypa.io/en/stable/reference/pip_install/#requirement-specifiers'
+        ' For instance use rtrace>=5.2 for radiance 5.2 or newer. Command will run '
+        ' rtrace --version and tries to parse version from command.'
+    )
 
     pip: List[Package] = Field(
         None,
         description='List of Python packages that are required for operator to '
-            'execute the commands locally. You must follow pip requirement specifiers: '
-            'https://pip.pypa.io/en/stable/reference/pip_install/#requirement-specifiers'
-        )
+        'execute the commands locally. You must follow pip requirement specifiers: '
+        'https://pip.pypa.io/en/stable/reference/pip_install/#requirement-specifiers'
+    )
 
     npm: List[Package] = Field(
         None,
         description='List of npm packages that are required for operator to '
-            'execute the commands locally. You must follow npm install requirements: '
-            'https://docs.npmjs.com/cli/install#synopsis'
-        )
+        'execute the commands locally. You must follow npm install requirements: '
+        'https://docs.npmjs.com/cli/install#synopsis'
+    )
 
     # NOTE: yaml conversion doesn't play well with Enum hence using a validator.
     @validator('platform')
@@ -114,7 +114,8 @@ class LocalRequirements(BaseModel):
         for plat in v:
             assert plat in cls._valid_platforms, \
                 '{} is not a valid platform. Try one of these platforms:\n - {}'.format(
-                    plat, '\n - '.join(pl.title() for pl in cls._valid_platforms)
+                    plat, '\n - '.join(pl.title()
+                                       for pl in cls._valid_platforms)
                 )
         return v
 
@@ -130,8 +131,8 @@ class Operator(BaseModel):
     name: str = Field(
         ...,
         description='Operator name. This name should be unique among all the operators'
-            ' in your workflow.'
-        )
+        ' in your workflow.'
+    )
 
     version: str = Field(
         None,
@@ -146,5 +147,5 @@ class Operator(BaseModel):
     local: LocalRequirements = Field(
         None,
         description='An optional requirement object to specify requirements for local'
-            ' execution of the commands.'
-        )
+        ' execution of the commands.'
+    )

--- a/queenbee/schema/parser.py
+++ b/queenbee/schema/parser.py
@@ -15,7 +15,7 @@ def _check_list(lst, folder):
 
 def _import_dict_data(dictionary, folder):
     """find import_from keys if any.
-    
+
     Args:
         dictionary: Input dictionary to be parsed.
         folder: Starting folder for relative paths in dictionary.
@@ -45,12 +45,12 @@ def _import_dict_data(dictionary, folder):
 
 def parse_file(input_file):
     """Parse queenbee objects from an input JSON / YAML file.
-    
+
     This method will replace 'import_from' keys with the content from files recursively. 
-    
+
     Args:
         input_file: A YAML / JSON input file.
-    
+
     Returns:
         The content of the input file as a dictionary.
     """
@@ -59,8 +59,9 @@ def parse_file(input_file):
     assert os.path.isfile(input_file), 'Failed to find {}'.format(input_file)
 
     ext = input_file.split('.')[-1].lower()
-    assert  ext in ('json', 'yml', 'yaml'), \
-        'Invalid input file type: [{}]. Only JSON and YAML files are valid.'.format(ext)
+    assert ext in ('json', 'yml', 'yaml'), \
+        'Invalid input file type: [{}]. Only JSON and YAML files are valid.'.format(
+            ext)
 
     if ext == 'json':
         with open(input_file) as inf:
@@ -80,11 +81,13 @@ def parse_double_quotes_vars(input):
     match = re.findall(pattern, input, flags=re.MULTILINE)
     return match
 
+
 def parse_double_quote_workflow_vars(input):
     """Parse values between {{ workflow. }}."""
     pattern = r"{{\s*(workflow\.[_a-zA-Z0-9.\-\$#\?]*)\s*}}"
     match = re.findall(pattern, input, flags=re.MULTILINE)
     return match
+
 
 def replace_double_quote_vars(text, key, replace):
     """Take an input string with template keys and replace them"""

--- a/queenbee/schema/parser.py
+++ b/queenbee/schema/parser.py
@@ -79,3 +79,14 @@ def parse_double_quotes_vars(input):
     pattern = r"{{\s*([_a-zA-Z0-9.\-\$#\?]*)\s*}}"
     match = re.findall(pattern, input, flags=re.MULTILINE)
     return match
+
+def parse_double_quote_workflow_vars(input):
+    """Parse values between {{ workflow. }}."""
+    pattern = r"{{\s*(workflow\.[_a-zA-Z0-9.\-\$#\?]*)\s*}}"
+    match = re.findall(pattern, input, flags=re.MULTILINE)
+    return match
+
+def replace_double_quote_vars(text, key, replace):
+    """Take an input string with template keys and replace them"""
+    pattern = r"{{\s*" + key + r"\s*}}"
+    return re.sub(pattern, replace, text)

--- a/queenbee/schema/qutil.py
+++ b/queenbee/schema/qutil.py
@@ -6,10 +6,14 @@ import json
 
 # set up yaml.dump to keep the order of the input dictionary
 # from https://stackoverflow.com/a/31609484/4394669
+
+
 def _keep_name_order_in_yaml():
     represent_dict_order = \
-        lambda self, data:  self.represent_mapping('tag:yaml.org,2002:map', data.items())
+        lambda self, data:  self.represent_mapping(
+            'tag:yaml.org,2002:map', data.items())
     yaml.add_representer(dict, represent_dict_order)
+
 
 _keep_name_order_in_yaml()
 

--- a/queenbee/schema/workflow.py
+++ b/queenbee/schema/workflow.py
@@ -129,7 +129,14 @@ class Workflow(BaseModel):
 
 
 def hydrate_templates(workflow, wf_value=None):
-    """cyle through an arbitary workflow value (dictionary, list, string etc...) and hydrate any workflow template value with it's actual value"""
+    """Replace all `{{ workflow.x.y.z }}` with corresponding value
+
+    Cyle through an arbitary workflow value (dictionary, list, string etc...) 
+    and hydrate any workflow template value with it's actual value. This command 
+    should mostly be used by the plugin libraries when converting a queenbee 
+    workflow to their own job scheduling language. As such the workflow should 
+    contain all the required variable values indicated by a `{{ workflow.x.y...z }}`.
+    """
 
     if isinstance(wf_value, list):
         wf_value = [hydrate_templates(workflow, item) for item in wf_value]

--- a/tests/assets/workflow_example/daylightfactor.yaml
+++ b/tests/assets/workflow_example/daylightfactor.yaml
@@ -5,15 +5,15 @@ name: daylight-factor
 artifact_locations:
   - type: local
     name: project-folder
-    root: /path/to/test
+    root: /path/to/test/{{ workflow.id }}
 
 inputs:
   parameters:
     - name: worker
       description: Maximum number of workers for executing this workflow.
       value: 1   # this is the default value which can be overwritten
-    - name: sensor-grid-path
-      description: Relative source_path to sensor grid from project folder.
+    - name: sensor-count
+      description: Number of sensors per split grid.
     - name: scene-file-paths
       description: A list of file paths to input as assets to the rtrace command
   artifacts:
@@ -158,7 +158,7 @@ flow:
       arguments:
         parameters:
           - name: sensor-count
-            value: "{{ workflow.inputs.parameters.sensor-count }}"
+            value: "{{ workflow.inputs.parameters.sensor-count.value }}"
 
     - name: create-octree
       template: create-octree
@@ -167,7 +167,7 @@ flow:
       arguments:
         parameters:
           - name: scene-file-paths
-            value: "{{ workflow.inputs.parameters.scene-file-paths }}"
+            value: "{{ workflow.inputs.parameters.scene-file-paths.value }}"
         artifacts:
           - name: sky-file
             source_path: "{{ tasks.generate-sky.outputs.artifacts.sky.path }}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import shutil
 
+
 @pytest.fixture(autouse=True)
 def temp_folder():
     os.mkdir('tests/assets/temp/')

--- a/tests/schema/arguments_test.py
+++ b/tests/schema/arguments_test.py
@@ -20,7 +20,6 @@ def test_load_arguments():
     artifact.path == 'project'
 
 
-
 def test_create_arguments():
     args_dict = {
         'parameters': [{'name': 'worker', 'value': 1}],

--- a/tests/schema/artifact_location_test.py
+++ b/tests/schema/artifact_location_test.py
@@ -3,6 +3,7 @@ from queenbee.schema.qutil import BaseModel
 from typing import List, Union
 import yaml
 
+
 class ArtifactLocationReader(BaseModel):
 
     artifact_locations: List[Union[LocalLocation, HTTPLocation, S3Location]]
@@ -26,6 +27,7 @@ def test_create_local_location():
 
     assert obj == loc.to_dict()
 
+
 def test_create_http_location():
     loc_dict = {
         'name': 'http-test',
@@ -46,6 +48,7 @@ def test_create_http_location():
         obj = yaml.safe_load(inf.read())
 
     assert obj == loc.to_dict()
+
 
 def test_create_s3_location():
     loc_dict = {
@@ -68,8 +71,10 @@ def test_create_s3_location():
 
     assert obj == loc.to_dict()
 
+
 def test_load_artifact_locations():
-    locs = ArtifactLocationReader.from_file('./tests/assets/artifact_locations.yaml')
+    locs = ArtifactLocationReader.from_file(
+        './tests/assets/artifact_locations.yaml')
 
     local_dict = {
         'name': 'local-test',
@@ -97,4 +102,3 @@ def test_load_artifact_locations():
     locs.artifact_locations[0].to_dict() == local_dict
     locs.artifact_locations[2].to_dict() == http_dict
     locs.artifact_locations[2].to_dict() == s3_dict
-

--- a/tests/schema/function_test.py
+++ b/tests/schema/function_test.py
@@ -12,7 +12,7 @@ def test_load_function():
 
 def test_load_illegal_input():
     fp = './tests/assets/function_illegal_input.yaml'
-    
+
     with pytest.raises(ValidationError):
         Function.from_file(fp)
 
@@ -23,5 +23,5 @@ def test_load_workflow_input():
     with warnings.catch_warnings(record=True) as catcher:
         warnings.simplefilter('always')
         Function.from_file(fp)
-        assert len(catcher) == 1 # there was a warning
+        assert len(catcher) == 1  # there was a warning
         assert 'workflow.parameters.sky-file' in str(catcher[0].message)

--- a/tests/schema/operator_test.py
+++ b/tests/schema/operator_test.py
@@ -7,11 +7,11 @@ def test_load_operator():
     operator = Operator.from_file(fp)
 
     assert operator.name == 'honeybee-radiance'
-    
+
     # check image
     image = operator.image
     image == 'ladybugtools/honeybee-radiance-workflow:latest'
-    
+
     # more checks is not really helpful as successful load to Pydantic object means
     # the object has been loaded correctly.
 
@@ -29,22 +29,22 @@ def test_create_operator():
                     'pattern': "r'\\d+\\.\\d+'"
                 }
             ],
-        'pip': [
-            {
-                'name': 'lbt-honeybee',
-                'version': '>=0.4.3'
-            },
-            {
-                'name': 'honeybee-radiance-workflow'
-            }],
-        'language': [
-            {
-                'name': 'python',
-                'version': '>=3.6'
-            }],
-        'platform': [
-            'Windows',
-            'Mac'
+            'pip': [
+                {
+                    'name': 'lbt-honeybee',
+                    'version': '>=0.4.3'
+                },
+                {
+                    'name': 'honeybee-radiance-workflow'
+                }],
+            'language': [
+                {
+                    'name': 'python',
+                    'version': '>=3.6'
+                }],
+            'platform': [
+                'Windows',
+                'Mac'
             ]
         }
     }
@@ -59,4 +59,3 @@ def test_create_operator():
         obj = yaml.safe_load(inf.read())
 
     assert obj == operator.to_dict()
-

--- a/tests/schema/workflow_test.py
+++ b/tests/schema/workflow_test.py
@@ -9,29 +9,36 @@ def test_load_workflow():
     fp = './tests/assets/workflow_example/daylightfactor.yaml'
     Workflow.from_file(fp)
 
+
 def test_workflow_fetch_dict():
     fp = './tests/assets/workflow_example/daylightfactor.yaml'
     wf = Workflow.from_file(fp)
 
     output = wf.fetch_workflow_values('{{workflow.inputs.parameters.worker}}')
 
-    assert output == {'workflow.inputs.parameters.worker': {'name': 'worker', 'path': None, 'description': 'Maximum number of workers for executing this workflow.', 'value': 1}}
-    
+    assert output == {'workflow.inputs.parameters.worker': {'name': 'worker', 'path': None,
+                                                            'description': 'Maximum number of workers for executing this workflow.', 'value': 1}}
+
+
 def test_workflow_fetch_value():
     fp = './tests/assets/workflow_example/daylightfactor.yaml'
     wf = Workflow.from_file(fp)
 
-    output = wf.fetch_workflow_values('{{workflow.inputs.parameters.worker.value}}')
+    output = wf.fetch_workflow_values(
+        '{{workflow.inputs.parameters.worker.value}}')
 
     assert output == {'workflow.inputs.parameters.worker.value': 1}
+
 
 def test_workflow_fetch_multi():
     fp = './tests/assets/workflow_example/daylightfactor.yaml'
     wf = Workflow.from_file(fp)
 
-    output = wf.fetch_workflow_values('{{workflow.inputs.parameters.worker.value}}-something-{{workflow.operators.honeybee-radiance.image}}')
+    output = wf.fetch_workflow_values(
+        '{{workflow.inputs.parameters.worker.value}}-something-{{workflow.operators.honeybee-radiance.image}}')
 
-    assert output == {'workflow.inputs.parameters.worker.value': 1, 'workflow.operators.honeybee-radiance.image': 'ladybugtools/honeybee-radiance'}
+    assert output == {'workflow.inputs.parameters.worker.value': 1,
+                      'workflow.operators.honeybee-radiance.image': 'ladybugtools/honeybee-radiance'}
 
 
 def test_hydrate_templates():
@@ -42,7 +49,6 @@ def test_hydrate_templates():
     wf.inputs.parameters[1].value = 50
     wf.inputs.parameters[2].value = 'path/to/scene/files'
 
-
     new_wf = wf.hydrate_workflow_templates()
 
     # Test string allocation
@@ -52,6 +58,7 @@ def test_hydrate_templates():
     # Test string concatenation
     assert new_wf.artifact_locations[0].root == "/path/to/test/some-test-id"
 
+
 def test_hydrate__missing_value_error():
     fp = './tests/assets/workflow_example/daylightfactor.yaml'
     wf = Workflow.from_file(fp)
@@ -59,5 +66,5 @@ def test_hydrate__missing_value_error():
     with pytest.raises(AssertionError) as e:
         new_wf = wf.hydrate_workflow_templates()
 
-    assert '{{workflow.inputs.parameters.sensor-count.value}} cannot reference an empty or null value.' in str(e)
-
+    assert '{{workflow.inputs.parameters.sensor-count.value}} cannot reference an empty or null value.' in str(
+        e)

--- a/tests/schema/workflow_test.py
+++ b/tests/schema/workflow_test.py
@@ -1,3 +1,4 @@
+import pytest
 from queenbee.schema.workflow import Workflow
 
 
@@ -7,3 +8,56 @@ def test_load_workflow():
     # is the test for the schema and every other part has been already tested.
     fp = './tests/assets/workflow_example/daylightfactor.yaml'
     Workflow.from_file(fp)
+
+def test_workflow_fetch_dict():
+    fp = './tests/assets/workflow_example/daylightfactor.yaml'
+    wf = Workflow.from_file(fp)
+
+    output = wf.fetch_workflow_values('{{workflow.inputs.parameters.worker}}')
+
+    assert output == {'workflow.inputs.parameters.worker': {'name': 'worker', 'path': None, 'description': 'Maximum number of workers for executing this workflow.', 'value': 1}}
+    
+def test_workflow_fetch_value():
+    fp = './tests/assets/workflow_example/daylightfactor.yaml'
+    wf = Workflow.from_file(fp)
+
+    output = wf.fetch_workflow_values('{{workflow.inputs.parameters.worker.value}}')
+
+    assert output == {'workflow.inputs.parameters.worker.value': 1}
+
+def test_workflow_fetch_multi():
+    fp = './tests/assets/workflow_example/daylightfactor.yaml'
+    wf = Workflow.from_file(fp)
+
+    output = wf.fetch_workflow_values('{{workflow.inputs.parameters.worker.value}}-something-{{workflow.operators.honeybee-radiance.image}}')
+
+    assert output == {'workflow.inputs.parameters.worker.value': 1, 'workflow.operators.honeybee-radiance.image': 'ladybugtools/honeybee-radiance'}
+
+
+def test_hydrate_templates():
+    fp = './tests/assets/workflow_example/daylightfactor.yaml'
+    wf = Workflow.from_file(fp)
+
+    wf.id = 'some-test-id'
+    wf.inputs.parameters[1].value = 50
+    wf.inputs.parameters[2].value = 'path/to/scene/files'
+
+
+    new_wf = wf.hydrate_workflow_templates()
+
+    # Test string allocation
+    assert new_wf.flow.tasks[2].arguments.parameters[0].value == 'path/to/scene/files'
+    # Test number allocation
+    assert new_wf.flow.tasks[1].arguments.parameters[0].value == 50
+    # Test string concatenation
+    assert new_wf.artifact_locations[0].root == "/path/to/test/some-test-id"
+
+def test_hydrate__missing_value_error():
+    fp = './tests/assets/workflow_example/daylightfactor.yaml'
+    wf = Workflow.from_file(fp)
+
+    with pytest.raises(AssertionError) as e:
+        new_wf = wf.hydrate_workflow_templates()
+
+    assert '{{workflow.inputs.parameters.sensor-count.value}} cannot reference an empty or null value.' in str(e)
+


### PR DESCRIPTION
I added this is as I was encountering issues with Argo whereby I wanted to set the path of an artifact to be `argo/pollination/job/{{ workflow.id}}`.

I could have written these methods in the other repo but this felt like the kind of thing we should add to queenbee.

I also added some minor fix to pydantic enums (deleted them :stuck_out_tongue: ) and added one-line doc to the `validate` command.