### PR TITLE
fix(docs): add pip install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
   - stage: docs
     if: branch = master AND (NOT type IN (pull_request))
     script:
+    - pip install -U .
     - python ./docs.py
     deploy:
       provider: pages


### PR DESCRIPTION
To be able to get the version we need to install the latest version of queenbee from pip before creating the docs.