### PR TITLE
Add new fields for info and user_data

### DIFF
--- a/queenbee/schema/arguments.py
+++ b/queenbee/schema/arguments.py
@@ -191,6 +191,9 @@ class Arguments(BaseModel):
     Queenbee accepts two types of arguments: parameters and artifacts. A ``parameter``
     is a variable that can be passed to a task or a workflow. An ``artifact`` is a file
     or folder that can be identified by a url or a path.
+
+    There is a third field for ``user_data`` which can be used to assign arbitrary values
+    to a workflow.
     """
 
     parameters: List[Parameter] = Field(
@@ -204,6 +207,12 @@ class Arguments(BaseModel):
         None,
         description='Artifacts is the list of file and folder arguments to pass to the '
         'task or workflow.'
+    )
+
+    user_data: Dict = Field(
+        None,
+        description='Optional user data as a dictionary. User data is for user reference'
+        ' only and will not be used in the execution of the workflow.'
     )
 
     @root_validator

--- a/queenbee/schema/arguments.py
+++ b/queenbee/schema/arguments.py
@@ -191,9 +191,6 @@ class Arguments(BaseModel):
     Queenbee accepts two types of arguments: parameters and artifacts. A ``parameter``
     is a variable that can be passed to a task or a workflow. An ``artifact`` is a file
     or folder that can be identified by a url or a path.
-
-    There is a third field for ``user_data`` which can be used to assign arbitrary values
-    to a workflow.
     """
 
     parameters: List[Parameter] = Field(
@@ -207,12 +204,6 @@ class Arguments(BaseModel):
         None,
         description='Artifacts is the list of file and folder arguments to pass to the '
         'task or workflow.'
-    )
-
-    user_data: Dict = Field(
-        None,
-        description='Optional user data as a dictionary. User data is for user reference'
-        ' only and will not be used in the execution of the workflow.'
     )
 
     @root_validator
@@ -293,3 +284,16 @@ class Arguments(BaseModel):
             ]
 
         return ref_values
+
+
+class WorkflowArguments(Arguments):
+    """A workflow arguments object.
+
+    The difference between the workflow argument and a standard argument is the extra
+    field for user_data.
+    """
+    user_data: Dict = Field(
+        None,
+        description='Optional user data as a dictionary. User data is for user reference'
+        ' only and will not be used in the execution of the workflow.'
+    )

--- a/queenbee/schema/info.py
+++ b/queenbee/schema/info.py
@@ -1,0 +1,64 @@
+"""Queenbee Info class.
+
+This object provides metadata information for a workflow.
+
+The specification is designed based on openapi info object:
+https://swagger.io/specification/#infoObject
+"""
+
+from queenbee.schema.qutil import BaseModel
+from pydantic import Field
+
+
+class Contact(BaseModel):
+    """Contact information."""
+    name: str = Field(
+        ...,
+        description='The name of the contact person or organization.'
+    )
+
+    url: str = Field(
+        None,
+        description='The url pointing to the contact information.'
+    )
+
+    email: str = Field(
+        None,
+        description='The email address of the contact person or organization.'
+    )
+
+
+class License(BaseModel):
+    """License information for the workflow."""
+    name: str = Field(
+        ...,
+        description='The license name used for the workflow.'
+    )
+
+    url: str = Field(
+        None,
+        description='A URL to the license used for the workflow.'
+    )
+
+
+class Info(BaseModel):
+    """Workflow meta data information."""
+    description: str = Field(
+        None,
+        description='A short description of the workflow.'
+    )
+
+    contact: Contact = Field(
+        None,
+        description='The contact information.'
+    )
+
+    license: License = Field(
+        None,
+        description='The license information.'
+    )
+
+    version: str = Field(
+        None,
+        description='The version of the workflow.'
+    )

--- a/queenbee/schema/metadata.py
+++ b/queenbee/schema/metadata.py
@@ -8,23 +8,24 @@ https://swagger.io/specification/#infoObject
 
 from queenbee.schema.qutil import BaseModel
 from pydantic import Field
+from typing import List, Union
 
 
-class Contact(BaseModel):
-    """Contact information."""
+class Author(BaseModel):
+    """Author information."""
     name: str = Field(
         ...,
-        description='The name of the contact person or organization.'
+        description='The name of the author person or organization.'
     )
 
     url: str = Field(
         None,
-        description='The url pointing to the contact information.'
+        description='The url pointing to the author information.'
     )
 
     email: str = Field(
         None,
-        description='The email address of the contact person or organization.'
+        description='The email address of the author person or organization.'
     )
 
 
@@ -48,9 +49,9 @@ class MetaData(BaseModel):
         description='A short description of the workflow.'
     )
 
-    contact: Contact = Field(
+    author: Union[Author, List[Author]] = Field(
         None,
-        description='The contact information.'
+        description='A single author or list of workflow authors.'
     )
 
     license: License = Field(

--- a/queenbee/schema/metadata.py
+++ b/queenbee/schema/metadata.py
@@ -1,4 +1,4 @@
-"""Queenbee Info class.
+"""Queenbee MetaData class.
 
 This object provides metadata information for a workflow.
 
@@ -41,8 +41,8 @@ class License(BaseModel):
     )
 
 
-class Info(BaseModel):
-    """Workflow meta data information."""
+class MetaData(BaseModel):
+    """Workflow metadata information."""
     description: str = Field(
         None,
         description='A short description of the workflow.'

--- a/queenbee/schema/workflow.py
+++ b/queenbee/schema/workflow.py
@@ -18,7 +18,7 @@ from queenbee.schema.artifact_location import RunFolderLocation, InputFolderLoca
     HTTPLocation, S3Location
 from queenbee.schema.parser import parse_double_quote_workflow_vars, \
     replace_double_quote_vars
-from queenbee.schema.info import Info
+from queenbee.schema.metadata import MetaData
 import queenbee.schema.variable as qbvar
 
 
@@ -31,7 +31,7 @@ class Workflow(BaseModel):
 
     id: str = str(uuid4())
 
-    info: Info = Field(
+    metadata: MetaData = Field(
         None,
         description='Workflow metadata information.'
     )

--- a/queenbee/schema/workflow.py
+++ b/queenbee/schema/workflow.py
@@ -11,7 +11,7 @@ from pydantic import Field, validator, constr
 from typing import List, Union
 from queenbee.schema.qutil import BaseModel
 from queenbee.schema.dag import DAG
-from queenbee.schema.arguments import Arguments
+from queenbee.schema.arguments import Arguments, WorkflowArguments
 from queenbee.schema.operator import Operator
 from queenbee.schema.function import Function
 from queenbee.schema.artifact_location import RunFolderLocation, InputFolderLocation, \
@@ -36,7 +36,7 @@ class Workflow(BaseModel):
         description='Workflow metadata information.'
     )
 
-    inputs: Arguments = Field(
+    inputs: WorkflowArguments = Field(
         None,
         description='Workflow input arguments.'
     )

--- a/queenbee/schema/workflow.py
+++ b/queenbee/schema/workflow.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import collections
 import re
 from graphviz import Digraph
-from pydantic import Field, validator, constr, root_validator
+from pydantic import Field, validator, constr
 from typing import List, Union
 from queenbee.schema.qutil import BaseModel
 from queenbee.schema.dag import DAG
@@ -18,6 +18,7 @@ from queenbee.schema.artifact_location import RunFolderLocation, InputFolderLoca
     HTTPLocation, S3Location
 from queenbee.schema.parser import parse_double_quote_workflow_vars, \
     replace_double_quote_vars
+from queenbee.schema.info import Info
 import queenbee.schema.variable as qbvar
 
 
@@ -30,8 +31,14 @@ class Workflow(BaseModel):
 
     id: str = str(uuid4())
 
+    info: Info = Field(
+        None,
+        description='Workflow metadata information.'
+    )
+
     inputs: Arguments = Field(
-        None
+        None,
+        description='Workflow input arguments.'
     )
 
     operators: List[Operator]
@@ -47,7 +54,8 @@ class Workflow(BaseModel):
     )
 
     outputs: Arguments = Field(
-        None
+        None,
+        description='Workflow output arguments.'
     )
 
     artifact_locations: List[

--- a/tests/schema/metadata.py
+++ b/tests/schema/metadata.py
@@ -1,0 +1,25 @@
+from queenbee.schema.metadata import MetaData
+
+single_author = {
+    'description': 'test metadata',
+    'author': {
+        'name': 'John Dao',
+        'email': 'jd@example.com'
+    }
+}
+
+multi_authors = {
+    'description': 'test metadata',
+    'author': [
+        {'name': 'John Smith', 'email': 'jos@example.com'},
+        {'name': 'Jane Smith', 'email': 'jas@example.com'},
+    ]
+}
+
+
+def test_load_single_author():
+    MetaData.parse_obj(single_author)
+
+
+def test_load_multi_authors():
+    MetaData.parse_obj(multi_authors)


### PR DESCRIPTION
Info closely follows the openapi info object. It allows users to add description, version, license and contact information to a workflow. A couple of notes:

- I kept the name of the workflow as is not to make a breaking change. It might be a better implementation to move it under info.
- All the field are currently optional but we might want to make versioning required.
- Should we consider a license by default? Something like MIT or BSD?

I added user_data field separate from the other arguments input since I _feel_ it serves a different purpose and should be on its own. The current implementation accepts a dictionary and is optional.