### PR TITLE
build(setup.py): add cli assets to build

### DIFF
--- a/docs/MANIFEST.in
+++ b/docs/MANIFEST.in
@@ -1,0 +1,2 @@
+include queenbee/cli/assets/*.yaml
+include queenbee/cli/assets/queenbee-art.txt

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setuptools.setup(
     entry_points={
         "console_scripts": ["queenbee = queenbee.cli:main"]
     },
+    include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
The template yaml files for cli was missing from the package.