### PR TITLE
docs(repository): improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ borrows a number of terms and expressions from
 [Apache Airflow](http://airflow.apache.org/) and [Ansible](https://docs.ansible.com/).
 
 Queenbee populates and validates the workflows but does not run them! For running the
-workflows see `ladybug-tools/workerbee` which converts Queenbee workflows to executable
+workflows see
+[`ladybug-tools/queenbee-luigi`](https://github.com/ladybug-tools/queenbee-luigi)
+which converts Queenbee workflows to executable
 [Luigi](https://luigi.readthedocs.io/en/stable/) pipelines.
 
 You can find more workflow samples in
@@ -41,7 +43,7 @@ You can also access the [Schema Documentation](https://ladybug.tools/queenbee/re
     ```
 
     or
- 
+
     ```console
     git clone https://github.com/ladybug-tools/queenbee
     ```
@@ -73,4 +75,4 @@ You can also access the [Schema Documentation](https://ladybug.tools/queenbee/re
     python -m http.server --directory ./docs/_build/
     ```
 
-    Now you can see the documentation preview [here](http://localhost:8000)
+    Now you can see the documentation preview at http://localhost:8000

--- a/docs/guides/repository.rst
+++ b/docs/guides/repository.rst
@@ -19,7 +19,7 @@ Folder Structure
 We will create a new Queenbee repository in a folder called ``local-queenbee-repo``. To do
 so run the following command::
 
-    queenbee repository init local-queenbee-argo
+    queenbee repository init local-queenbee-repo
 
 
 This command will create the folders and initialize an empty ``index.json`` file. Here
@@ -48,6 +48,9 @@ created in the `Operator Guide <operator.html>`_ (or any other operator you migh
 created). ::
 
     queenbee operator package path/to/operator --destination local-queenbee-repo/operators
+
+If you are using the Operator we created in the `Operator Guide <operator.html>`_ the
+path/to/operator is the ``energy-plus`` Operator folder.
 
 You should now see a new file has been added to your repository.
 
@@ -115,7 +118,7 @@ If you open your ``index.json`` file you will see that is has changed to somethi
 There are a few interesting things going on here:
 
 - The operator package is nested under the ``operator`` key
-- The operator name key points to a list of **Operator Versions**
+- The operator name key points to a list of **Operator Versions**. In this example the key is ``energy-plus``.
 - The **Operator Version** ``url`` key points to the package file relative to the ``index.json`` file
 - A ``digest`` is generated for each **Operator Version** This is used to handle ``version`` overwrites
 
@@ -138,7 +141,13 @@ To work with a local repository you must expose it as a local server on your mac
 You should now be able to view your ``index.json`` file from your browser at the
 following address `http://localhost:8000/index.json <http://localhost:8000/index.json>`_.
 
-If we write a Recipe that depends on the ``energy-plus``operator used in the examples above
+..  note::
+    If the port 8000 is not available you can change the port using ``--port`` option.
+    For instance ``queenbee repository serve local-queenbee-repo --port 8080`` will view
+    your ``index.json`` file at the following address:
+    `http://localhost:8080/index.json <http://localhost:8080/index.json>`_.
+
+If we write a Recipe that depends on the ``energy-plus`` operator used in the examples above
 we can write the ``dependencies.yaml`` file as follows::
 
     dependencies:

--- a/queenbee/cli/recipe/install.py
+++ b/queenbee/cli/recipe/install.py
@@ -16,11 +16,11 @@ except ImportError:
 @click.argument('path', type=click.Path(exists=True))
 def install(path):
     """download dependencies and save them to the .dependencies folder
-    
-    This subcommand interacts mostly with the ``dependencies.yaml`` file and 
+
+    This subcommand interacts mostly with the ``dependencies.yaml`` file and
     ``.dependencies`` folder in your recipe folder.
     """
-    
+
     try:
         recipe = Recipe.from_folder(path)
     except ValidationError as error:

--- a/queenbee/cli/recipe/new.py
+++ b/queenbee/cli/recipe/new.py
@@ -13,6 +13,7 @@ except ImportError:
 
 MODULE_PATH = os.path.abspath(os.path.dirname(__file__))
 
+
 @click.command('new')
 @click.argument('name')
 @click.option(
@@ -22,7 +23,7 @@ MODULE_PATH = os.path.abspath(os.path.dirname(__file__))
 )
 def new(name, path):
     """create a new recipe folder
-    
+
     Use this command to create a new recipe. The folder will compile to the following
     recipe definition::
 
@@ -61,7 +62,7 @@ def new(name, path):
             from:
                 type: tasks
                 name: say-something
-                variable: whale-said  
+                variable: whale-said
 
     You can indicate where you want to create the recipe folder by
     specifying the ``--path`` option.
@@ -81,7 +82,7 @@ def new(name, path):
     input_dict['metadata']['name'] = name
 
     recipe = Recipe.parse_obj(input_dict)
-    
+
     # Create entire path to folder if it does not exist
     os.makedirs(folder_path, exist_ok=True)
 

--- a/queenbee/cli/repository/index.py
+++ b/queenbee/cli/repository/index.py
@@ -15,7 +15,7 @@ MODULE_PATH = os.path.abspath(os.path.dirname(__file__))
 
 @click.command('index')
 @click.argument('path', type=click.Path(exists=True))
-@click.option('-i', '--index', 'index_path', help='Path to the index file to read/write to')
+@click.option('-i', '--index', 'index_path', help='Path to the index file to read/write to', show_default=True)
 @click.option('-n', '--new', help='Delete previous index and generate a new one from scratch', default=False, type=bool, is_flag=True)
 @click.option('-f', '--force', help='Overwrite existing package entries is digest hash does not match', default=False, type=bool, is_flag=True)
 @click.option('-s', '--skip', help='Skip any packages that would otherwise be overwritten', default=False, type=bool, is_flag=True)

--- a/queenbee/cli/repository/serve.py
+++ b/queenbee/cli/repository/serve.py
@@ -14,8 +14,8 @@ MODULE_PATH = os.path.abspath(os.path.dirname(__file__))
 
 @click.command('serve')
 @click.argument('path', type=click.Path(exists=True))
-@click.option('-p', '--port', 'port', help='The port to expose', default=8000)
-@click.option('-a', '--address', 'address', help='The host addres to use', default='0.0.0.0')
+@click.option('-p', '--port', 'port', help='The port to expose', default=8000, show_default=True)
+@click.option('-a', '--address', 'address', help='The host addres to use', default='0.0.0.0', show_default=True)
 def serve(port, address, path):
     """serve a local repository folder
 


### PR DESCRIPTION
The only real bug was using  `local-queenbee-argo` instead of `local-queenbee-repo` in one of the commands.