### PR TITLE
Recipe review

### DIFF
--- a/queenbee/base/io.py
+++ b/queenbee/base/io.py
@@ -34,7 +34,6 @@ class IOBase(BaseModel):
 
     artifacts: List[IOItem]
 
-    @classmethod
     @validator('parameters', 'artifacts')
     def parameter_unique_names(cls, v):
         """Pydantic validator to check that IO item names are unique within their list

--- a/queenbee/recipe/dependency.py
+++ b/queenbee/recipe/dependency.py
@@ -97,6 +97,8 @@ class Dependency(BaseModel):
         else:
             url = os.path.join(self.source, 'index.json')
 
+        # replace \\ with / for the case of Windows
+        url = url.replace('\\', '/')
         res = request.urlopen(url)
         raw_bytes = res.read()
         return RepositoryIndex.parse_raw(raw_bytes)
@@ -148,8 +150,7 @@ class Dependency(BaseModel):
                 else:
                     raise error
 
-        package_url = os.path.join(self.source, package_meta.url)
-
+        package_url = os.path.join(self.source, package_meta.url).replace('\\', '/')
         res = request.urlopen(package_url)
 
         filebytes = BytesIO(res.read())

--- a/queenbee/recipe/recipe.py
+++ b/queenbee/recipe/recipe.py
@@ -184,7 +184,7 @@ class Recipe(BaseModel):
         Returns:
             bool -- True if all dependencies are locked
         """
-        return all(map(lambda x: x.is_locked(), self.dependencies))
+        return all(map(lambda x: x.is_locked, self.dependencies))
 
     @staticmethod
     def dependency_by_name(dependencies: List[Dependency], name: str) -> Dependency:

--- a/queenbee/repository/index.py
+++ b/queenbee/repository/index.py
@@ -53,14 +53,16 @@ class RepositoryIndex(BaseModel):
             for package in os.listdir(operators_folder):
                 package_path = os.path.join(folder_path, 'operators', package)
                 resource_version = OperatorVersion.from_package(package_path)
-                resource_version.url = os.path.join('operators', package)
+                resource_version.url = \
+                    os.path.join('operators', package).replace('\\', '/')
                 index.index_operator_version(resource_version)
 
         if os.path.exists(recipes_folder):
             for package in os.listdir(recipes_folder):
                 package_path = os.path.join(folder_path, 'recipes', package)
                 resource_version = RecipeVersion.from_package(package_path)
-                resource_version.url = os.path.join('recipes', package)
+                resource_version.url = \
+                    os.path.join('recipes', package).replace('\\', '/')
                 index.index_recipe_version(resource_version)
 
         index.generated = datetime.utcnow()

--- a/queenbee/repository/package.py
+++ b/queenbee/repository/package.py
@@ -137,7 +137,7 @@ class ResourceVersion(BaseModel):
         Returns:
             ResourceVersion -- A resource version object
         """
-        file_path = os.path.abspath(package_path)
+        file_path = os.path.normpath(os.path.abspath(package_path))
 
         tar_file = TarFile.open(file_path)
 
@@ -145,7 +145,12 @@ class ResourceVersion(BaseModel):
 
         version_bytes = tar_file.extractfile(member).read()
 
-        return cls.parse_raw(version_bytes)
+        cls_ = cls.parse_raw(version_bytes)
+
+        # add subfolder (e.g. operators, recipes ) to url
+        cls_.url = '/'.join(file_path.split(os.sep)[-2:])
+
+        return cls_
 
     @staticmethod
     def path_to_readme(folder_path: str) -> str:


### PR DESCRIPTION
This PR fixes two issues with recipe and dependency creation:

1. The URL handling for Windows is fixed.
2. The package URL is fixed.

@AntoineDao, the package_url was missing the subfolder. <s>Not sure if you like my implementation. I added it in the object when it returns the url but it can also be implemented in operator index.json itself to have the full url. `operators/energy-plus-0.1.0.tgz` instead of `energy-plus-0.1.0.tgz`.</s>

It was `http://localhost:8000/energy-plus-0.1.0.tgz` but should have been `http://localhost:8000/operators/energy-plus-0.1.0.tgz`