### PR TITLE
Dev link

### DIFF
--- a/queenbee/cli/recipe/__init__.py
+++ b/queenbee/cli/recipe/__init__.py
@@ -2,6 +2,7 @@ from .new import new
 from .lint import lint
 from .package import package
 from .install import install
+from .link import link
 
 try:
     import click
@@ -23,14 +24,26 @@ def main(ctx):
     as shown below::
 
         \b
-        recipe-name
+        .
         ├── .dependencies
-        │   ├── operators
-        │   │   └── <sha-256>.yaml
-        │   └── recipes
-        │       └── <sha-256>.yaml
+        │   ├── operator
+        │   │   └── operator-dep-name
+        │   │       ├── functions
+        │   │       │   ├── func-1.yaml
+        │   │       │   ├── ...
+        │   │       │   └── func-n.yaml
+        │   │       ├── config.yaml
+        │   │       └── operator.yaml
+        │   └── recipe
+        │       └── recipe-dep-name
+        │           ├── .dependencies
+        │           │   ├── operator
+        │           │   └── recipe
+        │           ├── flow
+        │           │   └── main.yaml
+        │           ├── dependencies.yaml
+        │           └── recipe.yaml
         ├── flow
-        |   ├── sub-dag.yaml
         │   └── main.yaml
         ├── dependencies.yaml
         └── recipe.yaml
@@ -64,3 +77,5 @@ main.add_command(new)
 main.add_command(lint)
 main.add_command(package)
 main.add_command(install)
+main.add_command(link)
+

--- a/queenbee/cli/recipe/link.py
+++ b/queenbee/cli/recipe/link.py
@@ -1,0 +1,48 @@
+import os
+import shutil
+
+from pydantic import ValidationError
+
+from ...recipe import Recipe, BakedRecipe
+from ...repository import RecipeVersion
+
+try:
+    import click
+    from click_plugins import with_plugins
+except ImportError:
+    raise ImportError(
+        'click modules not installed. Try `pip install queenbee[cli]` command.'
+    )
+
+@click.command('link')
+@click.argument('dependency_name')
+@click.argument('dependency_path', type=click.Path(exists=True))
+@click.option('-r', '--recipe-path', help='Path to the recipe folder where link should be created', show_default=True, default='.', type=click.Path(exists=False))
+def link(dependency_name, dependency_path, recipe_path):
+    """link a local recipe/operator to a dependency of another recipe
+
+    This subcommand helps develop recipes and operators at the same time without
+    needing to update source repositories.
+    """
+
+    recipe = Recipe.from_folder(recipe_path)
+
+    try:
+        dependency = recipe.dependency_by_name(recipe.dependencies, dependency_name)
+    except ValueError as error:
+        raise click.ClickException(error)
+
+    destination = os.path.join(recipe_path, '.dependencies', dependency.type, dependency_name)
+    destination = os.path.abspath(destination)
+
+    source = os.path.abspath(dependency_path)
+
+    if os.path.exists(destination):
+        if os.path.isdir(destination):
+            shutil.rmtree(destination)
+        else:
+            os.remove(destination)
+
+    os.makedirs(os.path.dirname(destination), exist_ok=True)
+
+    os.symlink(source, destination)

--- a/queenbee/operator/operator.py
+++ b/queenbee/operator/operator.py
@@ -113,6 +113,7 @@ class Operator(BaseModel):
         Returns:
             Operator -- An operator
         """
+        folder_path = os.path.realpath(folder_path)
         meta_path = os.path.join(folder_path, 'operator.yaml')
         config_path = os.path.join(folder_path, 'config.yaml')
         functions_path = os.path.join(folder_path, 'functions')
@@ -155,13 +156,14 @@ class Operator(BaseModel):
         Arguments:
             folder_path {str} -- Path to write the folder to
         """
+        os.makedirs(os.path.join(folder_path, 'functions'))
+
         self.metadata.to_yaml(
             os.path.join(folder_path, 'operator.yaml'),
             exclude_unset=True
         )
         self.config.to_yaml(os.path.join(folder_path, 'config.yaml'), exclude_unset=True)
 
-        os.mkdir(os.path.join(folder_path, 'functions'))
 
         for function in self.functions:
             function.to_yaml(

--- a/queenbee/recipe/reference.py
+++ b/queenbee/recipe/reference.py
@@ -45,7 +45,7 @@ class InputBaseReference(BaseReference):
         Returns:
             str -- A reference string
         """
-        template = [self.type, self.source, self.variable]
+        template = [self.type.value, self.source, self.variable]
         return template_string(template)
 
 
@@ -86,7 +86,7 @@ class TaskBaseReference(BaseReference):
         Returns:
             str -- A reference string
         """
-        template = [self.type, self.source, self.name, self.variable]
+        template = [self.type.value, self.name, 'outputs', self.source, self.variable]
         return template_string(template)
 
 
@@ -123,7 +123,7 @@ class ItemBaseReference(BaseReference):
         Returns:
             str -- A reference string
         """
-        template = [self.type, self.source, self.variable]
+        template = [self.type.value, self.source, self.variable]
         return template_string(template)
 
 

--- a/queenbee/workflow/workflow.py
+++ b/queenbee/workflow/workflow.py
@@ -93,8 +93,10 @@ class Workflow(BaseModel):
         Returns:
             Workflow -- A workflow object
         """
-        input_dict = recipe.to_dict()
-        input_dict['arguments'] = arguments.to_dict()
-        input_dict['labels'] = labels
+        input_dict = {
+            'recipe': recipe.to_dict(),
+            'arguments': arguments.to_dict(),
+            'labels': labels,
+        }
 
         return cls.parse_obj(input_dict)

--- a/tests/assets/recipes/baked/daylight-factor.yaml
+++ b/tests/assets/recipes/baked/daylight-factor.yaml
@@ -283,7 +283,7 @@ templates:
     - name: grid
       description: The input grid to split
       path: grid.pts
-  command: honeybee radiance grid split grid.pts {{ inputs.parameters.grid-count }} --folder output --log-file output/grids.txt
+  command: honeybee radiance grid split grid.pts --folder output --log-file output/grids.txt
   outputs:
     parameters:
     - name: grid-list

--- a/tests/recipe/baked_recipe_test.py
+++ b/tests/recipe/baked_recipe_test.py
@@ -55,9 +55,12 @@ class TestFolder(BaseTestClass):
     def test_from_folder(self, folder):
         parsed_instance = BakedRecipe.from_folder(folder)
 
-        parsed_instance.to_yaml(
-            os.path.join(ASSET_FOLDER, 'baked', f'{parsed_instance.metadata.name}.yaml')
-        )
+        parsed_test_path = os.path.join(ASSET_FOLDER, 'baked', f'{parsed_instance.metadata.name}.yaml')
+
+        if os.path.exists(parsed_test_path):
+            compare_instance = BakedRecipe.from_file(parsed_test_path)
+
+            assert compare_instance == parsed_instance
 
     def test_from_recipe_instance(self, recipe):
         parsed_instance = BakedRecipe.from_recipe(recipe)


### PR DESCRIPTION
This PR aims to address #82. I more or less followed the system used by [`npm link`](https://docs.npmjs.com/cli/link) to achieve the following:

1. Develop an opertator `local-op` in `/path/to/operator/local-op`
2. Develop a recipe `local-rec` that has `local-op` as a dependency
3. Create a link between `local-op` and the dependencies folder of `local-rec` at `local-rec/.dependencies/operators/local-op`
4. Develop `local-op` and `local-rec` in tandem and create baked recipes from the `local-rec` folder


Let's show an example scenario where `local-rec` dependencies look like this:

```yaml
dependencies:
- type: operator
  name: honeybee-radiance
  hash: 4e6b9354ade52b792988abef4426d744b587fb26eaabbc681ad27c75aa0c8048
  version: 1.2.3
  source: https://example.com/test-repo
- type: operator
  name: local-op
  hash: 4e6b9354ade52b792988abef4426d744b587fb26eaabbc681ad27c75aa0c8048
  version: 1.2.3
  source: https://example.com/test-repo
```

The CLI command works like this:

```console
> cd local-op
> queenbee recipe link local-op /path/to/operator/local-op
```

In this command `local-op` is the name or alias of the dependency in the `dependencies.yml` file and `/path/to/operator/local-op` is the absolute or relative (it handles both) path to the operator folder we want to associate with this dependency in our `.dependencies` folder.

The link command will then create a `symlink` between `/path/to/operator/local-op` and `/path/to/recipe/local-rec/.dependencies/operator/local-op`.

**Warning**: Compiling a recipe into a baked recipe will only work if you compile it using the `from_folder` function and set `refresh_deps` to `False`. If you don't set `refresh_deps` to `False` queenbee will try to download the dependency from the defined source, check the `digest` hash etc...