### PR TITLE
fix(task): add support for fixed value in task artifact arguments

### DIFF
--- a/queenbee/recipe/dag.py
+++ b/queenbee/recipe/dag.py
@@ -187,6 +187,18 @@ class DAGTaskArtifactArgument(BaseModel):
         ' want to source an artifact from within that directory.'
     )
 
+    value: str = Field(
+        None,
+        description='The fixed value for this task argument.'
+    )
+
+    @validator('value')
+    def check_value_exists(cls, v):
+        if v is not None:
+            assert v.from_ is not None, \
+                ValueError('value must be specified if no "from" source is specified for argument artifact.')
+        return v
+
 
 class DAGTaskParameterArgument(BaseModel):
     """Input argument for a DAG task.

--- a/queenbee/recipe/dag.py
+++ b/queenbee/recipe/dag.py
@@ -11,7 +11,8 @@ from ..base.io import IOBase, find_dup_items
 from ..base.parser import parse_double_quotes_vars
 from .artifact_source import HTTPSource, S3Source, ProjectFolderSource
 from .reference import InputArtifactReference, InputParameterReference, \
-    TaskArtifactReference, TaskParameterReference, ItemParameterReference
+    TaskArtifactReference, TaskParameterReference, ItemParameterReference, \
+    FolderArtifactReference
 
 
 class DAGInputParameter(BaseModel):
@@ -174,7 +175,7 @@ class DAGTaskArtifactArgument(BaseModel):
         description='Name of the argument variable'
     )
 
-    from_: Union[InputArtifactReference, TaskArtifactReference] = Field(
+    from_: Union[InputArtifactReference, TaskArtifactReference, FolderArtifactReference] = Field(
         ...,
         alias='from',
         description='The previous task or global workflow variable to pull this argument'
@@ -186,18 +187,6 @@ class DAGTaskArtifactArgument(BaseModel):
         description='Specify this value if your source artifact is a repository and you'
         ' want to source an artifact from within that directory.'
     )
-
-    value: str = Field(
-        None,
-        description='The fixed value for this task argument.'
-    )
-
-    @validator('value')
-    def check_value_exists(cls, v):
-        if v is not None:
-            assert v.from_ is not None, \
-                ValueError('value must be specified if no "from" source is specified for argument artifact.')
-        return v
 
 
 class DAGTaskParameterArgument(BaseModel):

--- a/queenbee/recipe/reference.py
+++ b/queenbee/recipe/reference.py
@@ -29,6 +29,16 @@ class BaseReference(BaseModel):
         pass
 
 
+class FolderArtifactReference(BaseReference):
+
+    type: Enum('FolderReference', {'type': 'folder'}) = 'folder'
+
+    path: str = Field(
+        ...,
+        description='The path to the file or folder relative to the workflow output folder'
+    )
+
+
 class InputBaseReference(BaseReference):
     """An Input Reference"""
 


### PR DESCRIPTION
Added support for fixed value for artifact argument for a task. This is similar to what a parameter argument supports and is the minimum change that I need to be able to get the daylight-factor results aggregate work.

We need to add support for this in queenbee extensions.

Resolves #121