### PR TITLE
Fixes in order to get the local indexing to work

### DIFF
--- a/docs/schemas/recipes.rst
+++ b/docs/schemas/recipes.rst
@@ -56,7 +56,7 @@ Examples
 
 Minimal
 ^^^^^^^
-The minimal configuration for an recipe can be found below. The keys indicated here are the ones
+The minimal configuration for a recipe can be found below. The keys indicated here are the ones
 you **absolutely** have to fill in for this recipe to be validated by Queenbee.
 
 ..  literalinclude:: ../../tests/assets/recipes/valid/minimal.yaml

--- a/queenbee/base/request.py
+++ b/queenbee/base/request.py
@@ -12,7 +12,10 @@ def get_uri(url):
 
     if url.startswith('file:///'):
         return url.replace('\\', '/')
+    elif url.startswith('http://') or url.startswith('https://'):
+        return url
 
+    # a local file 
     try:
         uri = pathlib.Path(os.path.abspath(url)).as_uri()
     except ValueError:

--- a/queenbee/base/request.py
+++ b/queenbee/base/request.py
@@ -1,9 +1,24 @@
+import pathlib
+import os
 from urllib import request
 from typing import Union
-
 from .basemodel import BaseModel
 
 USER_AGENT_STRING = 'Queenbee'
+
+
+def get_uri(url):
+    """Resolve uri for urls and local files."""
+
+    if url.startswith('file:///'):
+        return url.replace('\\', '/')
+
+    try:
+        uri = pathlib.Path(os.path.abspath(url)).as_uri()
+    except ValueError:
+        uri = url
+
+    return uri
 
 
 def urljoin(*args):
@@ -13,7 +28,7 @@ def urljoin(*args):
         str: a clean url string
     """
     url = "/".join(map(lambda x: str(x).rstrip('/'), args))
-    url.replace('\\', '/')
+    url = url.replace('\\', '/')
 
     return url
 

--- a/queenbee/cli/recipe/package.py
+++ b/queenbee/cli/recipe/package.py
@@ -20,12 +20,12 @@ except ImportError:
 @click.option('-f', '--force', help='Boolean toggle to overwrite existing package with same name and version', default=False, type=bool, is_flag=True)
 @click.option('--no-update', help='Do not fetch fresh versions of dependencies before packaging', default=False, type=bool, is_flag=True)
 def package(path, destination, force, no_update):
-    """package an recipe
+    """package a recipe
 
     This command helps you package recipes and add them to repository folders. A packaged
     recipe is essentially a gzipped version of its folder.
 
-    You can package an recipe in a specific folder or repository by using the ``--destination``
+    You can package a recipe in a specific folder or repository by using the ``--destination``
     flag::
 
         queenbee recipe package path/to/my/recipe --destination path/to/my/repository/recipes

--- a/queenbee/cli/repository/init.py
+++ b/queenbee/cli/repository/init.py
@@ -20,7 +20,7 @@ def init(path):
 
     path = os.path.abspath(path)
 
-    os.makedirs(os.path.join(path, 'workflows'), exist_ok=True)
+    os.makedirs(os.path.join(path, 'operators'), exist_ok=True)
     os.makedirs(os.path.join(path, 'recipes'), exist_ok=True)
 
     index = RepositoryIndex.from_folder(path)

--- a/queenbee/cli/repository/manage.py
+++ b/queenbee/cli/repository/manage.py
@@ -1,6 +1,5 @@
 import os
 import json
-from urllib.parse import urlparse
 
 try:
     import click
@@ -25,12 +24,6 @@ def add(name, path, force):
     is useful to search, develop and use queenbee packages locally.
     """
     ctx = click.get_current_context()
-
-    parse_res = urlparse(path)
-
-    # Not a url, therefore local path
-    if parse_res.scheme == '':
-        path = os.path.abspath(path)
 
     try:
         ctx.obj.config.add_repository(

--- a/queenbee/cli/repository/search.py
+++ b/queenbee/cli/repository/search.py
@@ -63,12 +63,18 @@ def search(repository, package_type, search):
 @click.argument('type')
 @click.argument('repo')
 @click.argument('name')
-@click.argument('tag')
+@click.option('-t', '--tag', help='Package tag.', default='latest')
 def get_by_tag(type, repo, name, tag):
     """get and print a specific package
 
-    Use this command to print out a specific package version from a 
-    given repository. 
+    Use this command to print out a specific package version from a given repository.
+
+    type: Package type. It should be either an operator or a repository.
+
+    repo: The name of the repository.
+
+    name: Name of the package.
+
     """
 
     ctx = click.get_current_context()

--- a/queenbee/config/repositories.py
+++ b/queenbee/config/repositories.py
@@ -31,7 +31,7 @@ class RepositoryReference(BaseModel):
         from ..repository import RepositoryIndex
 
         if self.path.startswith('file:'):
-            url = os.path.join(self.path, 'index.json').replace('\\', '/')
+            url = os.path.join(self.path, 'index.json')
         else:
             url = urljoin(self.path, 'index.json')
 

--- a/queenbee/recipe/recipe.py
+++ b/queenbee/recipe/recipe.py
@@ -581,7 +581,8 @@ class BakedRecipe(Recipe):
                 except KeyError:
                     raise ValueError(
                         f'Unresolvable dependency name {dep.ref_name}. Did you forget '
-                        f' to package or link {dep.ref_name}?'
+                        f'to package or link {dep.ref_name}? '
+                        'See `queenbee recipe link --help` for more information.'
                     )
 
                 # Template name is another Recipe

--- a/queenbee/repository/index.py
+++ b/queenbee/repository/index.py
@@ -317,7 +317,7 @@ class RepositoryIndex(BaseModel):
                 index (default: {False})
         """
         self.recipe = self._index_resource_version(
-            self.recipe, recipe_version, overwrite
+            self.recipe, recipe_version, overwrite=overwrite
         )
         self.generated = datetime.utcnow()
 
@@ -333,19 +333,19 @@ class RepositoryIndex(BaseModel):
                 the index (default: {False})
         """
         self.operator = self._index_resource_version(
-            self.operator, operator_version, overwrite
+            self.operator, operator_version, overwrite=overwrite
         )
         self.generated = datetime.utcnow()
 
     def merge_folder(self, folder_path, overwrite: bool = False, skip: bool = False):
-        """Merge the contents of an repository folder with the index
+        """Merge the contents of a repository folder with the index
 
         Arguments:
             folder_path {str} -- The path to the repository folder
 
         Keyword Arguments:
             overwrite {bool} -- Overwrite any Resource Version (default: {False})
-            skip {bool} -- [description] (default: {False})
+            skip {bool} -- Skip any errors if version already exist (default: {False})
 
         Raises:
             ValueError: Resource version already exists or is invalid
@@ -353,6 +353,8 @@ class RepositoryIndex(BaseModel):
         for package in os.listdir(os.path.join(folder_path, 'operators')):
             package_path = os.path.join(folder_path, 'operators', package)
             resource_version = PackageVersion.from_package(package_path)
+            resource_version.url = \
+                    os.path.join('operators', package).replace('\\', '/')
             try:
                 self.index_operator_version(resource_version, overwrite)
             except ValueError as error:
@@ -364,6 +366,8 @@ class RepositoryIndex(BaseModel):
         for package in os.listdir(os.path.join(folder_path, 'recipes')):
             package_path = os.path.join(folder_path, 'recipes', package)
             resource_version = PackageVersion.from_package(package_path)
+            resource_version.url = \
+                    os.path.join('recipes', package).replace('\\', '/')
             try:
                 self.index_recipe_version(resource_version, overwrite)
             except ValueError as error:

--- a/queenbee/repository/package.py
+++ b/queenbee/repository/package.py
@@ -266,8 +266,6 @@ class PackageVersion(MetaData):
         with open(file_path, 'rb') as f:
             filebytes = BytesIO(f.read())
 
-        tar_file = TarFile.open(file_path)
-
         version = cls.unpack_tar(tar_file=filebytes, verify_digest=False)
 
         return version
@@ -275,11 +273,10 @@ class PackageVersion(MetaData):
     def fetch_package(self, source_url: str = None, verify_digest: bool = True, auth_header: str = '') -> 'PackageVersion':
         if source_url.startswith('file:'):
             source_path = source_url.split('file:///')[1]
-            subfolder = f'{self.type}s'
             if os.path.isabs(source_path):
-                package_path = os.path.join(source_path, subfolder, self.url)
+                package_path = os.path.join(source_path, self.url)
             else:
-                package_path = os.path.join(os.getcwd(), source_path, subfolder, self.url)
+                package_path = os.path.join(os.getcwd(), subfolder, self.url)
 
             return self.from_package(package_path)
 

--- a/queenbee/repository/package.py
+++ b/queenbee/repository/package.py
@@ -261,7 +261,7 @@ class PackageVersion(MetaData):
         Returns:
             PackageVersion -- A package version object
         """
-        file_path = os.path.normpath(os.path.abspath(package_path))
+        file_path = os.path.normpath(os.path.abspath(package_path)).replace('\\', '/')
 
         with open(file_path, 'rb') as f:
             filebytes = BytesIO(f.read())
@@ -274,12 +274,12 @@ class PackageVersion(MetaData):
 
     def fetch_package(self, source_url: str = None, verify_digest: bool = True, auth_header: str = '') -> 'PackageVersion':
         if source_url.startswith('file:'):
-            source_path = source_url.split('file:')[1]
-
+            source_path = source_url.split('file:///')[1]
+            subfolder = f'{self.type}s'
             if os.path.isabs(source_path):
-                package_path = os.path.join(source_path, self.url)
+                package_path = os.path.join(source_path, subfolder, self.url)
             else:
-                package_path = os.path.join(os.getcwd(), source_path, self.url)
+                package_path = os.path.join(os.getcwd(), source_path, subfolder, self.url)
 
             return self.from_package(package_path)
 
@@ -390,7 +390,7 @@ class PackageVersion(MetaData):
                 the recipe by baking it (default: {True})
 
         Returns:
-            PackageVersion -- An recipe or operator version object
+            PackageVersion -- A recipe or operator version object
             BytesIO -- A BytesIO stream of the gzipped tar file
         """
         if resource_type == 'recipe':


### PR DESCRIPTION
There are two commits that are related to development issues here:

- One that fixes the path issues for Windows path
- A second one that fixes the path for accessing the local resources

With these fixes I could create a local index and get `queenbee repo list` to work. Once this is merged I need to:

1. Send a new PR to honeybee-radiance-recipe repository with the new file structure.
2. Add a new command to Queenbee luigi to support the new way of getting the recipe from a repository instead of a baked recipe file.
3. Use the new command the Grasshopper component to deal with honeybee-radiance recipes.