### PR TITLE
Add alias input and output objects

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 coverage==5.3
 coveralls==2.1.2
-pytest==6.1.1
+pytest==6.1.2
 pytest-cov==2.10.1
 attrs~=20.2.0
 Sphinx==3.2.1

--- a/docs.py
+++ b/docs.py
@@ -6,7 +6,6 @@ from pydantic_openapi_helper.core import get_openapi
 from pydantic_openapi_helper.inheritance import class_mapper
 from queenbee.recipe.recipe import Recipe
 from queenbee.operator.operator import Operator
-from queenbee.io.dag import DAGBooleanInput
 
 
 parser = argparse.ArgumentParser(description='Generate OpenAPI JSON schemas')
@@ -21,7 +20,7 @@ VERSION = None
 if args.version:
     VERSION = args.version.replace('v', '')
 else:
-    VERSION = '.'.join(get_distribution('dragonfly_schema').version.split('.')[:3])
+    VERSION = '.'.join(get_distribution('queenbee').version.split('.')[:3])
 
 
 info = {
@@ -45,8 +44,8 @@ info = {
 
 
 modules = [
-    {'module': Recipe, 'name': 'Recipe'}
-    # {'module': Operator, 'name': 'Operator'}
+    {'module': Recipe, 'name': 'Recipe'},
+    {'module': Operator, 'name': 'Operator'}
 ]
 
 
@@ -65,8 +64,6 @@ for module in modules:
         description=f'Documentation for Queenbee {module["name"].lower()} schema.',
         version=VERSION, info=info,
         external_docs=external_docs)
-    # set the version default key in the Recipe schema
-    # openapi['components']['schemas']['Recipe']['properties']['version']['default'] = VERSION
     with open(f'./docs/{module["name"].lower()}.json', 'w') as out_file:
         json.dump(openapi, out_file, indent=2)
 
@@ -79,8 +76,6 @@ for module in modules:
         inheritance=True,
         external_docs=external_docs
     )
-    # set the version default key in the Recipe schema
-    # openapi['components']['schemas']['Recipe']['allOf'][1]['properties']['version']['default'] = VERSION
     with open(f'./docs/{module["name"].lower()}_inheritance.json', 'w') as out_file:
         json.dump(openapi, out_file, indent=2)
 

--- a/queenbee/io/common.py
+++ b/queenbee/io/common.py
@@ -14,12 +14,13 @@ from ..base.variable import validate_inputs_outputs_var_format, get_ref_variable
 
 class ItemType(str, Enum):
     """Type enum for items in a list."""
+    Any = 'Any'  # a generic type to be used when different types can be used.
     String = 'String'
     Integer = 'Integer'
     Number = 'Number'
     Boolean = 'Boolean'
     Folder = 'Folder'
-    Array = 'Array'
+    Array = 'Array'  # set item type to a generic type
     Object = 'Object'
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pydantic==1.7
+pydantic==1.7.1
 PyYAML==5.3.1
 jsonschema==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pydantic==1.7.1
+pydantic==1.7.2
 PyYAML==5.3.1
 jsonschema==3.2.0

--- a/tests/assets/recipes/baked/daylight-factor.yaml
+++ b/tests/assets/recipes/baked/daylight-factor.yaml
@@ -34,25 +34,68 @@ flow:
     description: A grid file
     default: null
     spec: null
+    alias: []
     extensions: null
   - annotations: {}
-    type: DAGFolderInput
-    name: model
-    description: A Honeybee model with radiance properties
+    type: DAGFileInput
+    name: model_hbjson
+    description: Honeybee model as a hbjson file.
     default: null
     spec: null
+    alias:
+    - annotations: {}
+      type: DAGGenericInputAlias
+      name: model
+      description: 'A path to a HBJSON file or a HB model object built with Python
+        or dotnet
+
+        libraries.
+
+        '
+      default: null
+      spec: null
+      platform:
+      - grasshopper
+      handler:
+      - annotations: {}
+        type: IOAliasHandler
+        language: python
+        module: honeybee_rhino.handlers
+        function: hb_model_to_hbjson
+      - annotations: {}
+        type: IOAliasHandler
+        language: csharp
+        module: HBRhino.Model
+        function: HBModelToJSON
+    - annotations: {}
+      type: DAGGenericInputAlias
+      name: model
+      description: null
+      default: null
+      spec: null
+      platform:
+      - rhino
+      handler:
+      - annotations: {}
+        type: IOAliasHandler
+        language: dotnet
+        module: HBRhino.Model
+        function: ExportRhinoModel
+    extensions: null
   - annotations: {}
     type: DAGStringInput
     name: radiance-parameters
     description: The radiance parameters for ray tracing
     default: -I -ab 2 -h
     spec: null
+    alias: []
   - annotations: {}
     type: DAGIntegerInput
     name: sensor-grid-count
     description: The maximum number of grid points per parallel execution
     default: null
     spec: null
+    alias: []
   outputs:
   - annotations: {}
     type: DAGIntegerOutput
@@ -63,6 +106,7 @@ flow:
       type: TaskReference
       name: post-process
       variable: daylight-factor-average
+    alias: []
   - annotations: {}
     type: DAGFolderOutput
     name: data
@@ -72,12 +116,13 @@ flow:
       type: TaskReference
       name: post-process
       variable: post-process-folder
-  name: a85a19d988a1fdbcf775b1b8e9ed2b26a5af0ab137bbc57b4268729aa6e8a8d5/main
+    alias: []
+  name: 8b959cb7cb3b5f24abd8ac64c03b44c457b318cc9494a7eeca514638edd43e34/main
   fail_fast: true
   tasks:
   - annotations: {}
     name: create-octree
-    template: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/create-octree
+    template: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/create-octree
     arguments:
     - annotations: {}
       type: TaskPathArgument
@@ -85,7 +130,7 @@ flow:
       from:
         annotations: {}
         type: InputFolderReference
-        variable: model
+        variable: model_hbjson
       sub_path: null
     - annotations: {}
       type: TaskPathArgument
@@ -107,7 +152,7 @@ flow:
       path: output/octree/scene.oct
   - annotations: {}
     name: daylight-factor-simulation
-    template: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/ray-tracing
+    template: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/ray-tracing
     arguments:
     - annotations: {}
       type: TaskArgument
@@ -151,7 +196,7 @@ flow:
       path: '{{item.name}}.res'
   - annotations: {}
     name: generate-sky
-    template: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/10000-lux-sky
+    template: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/10000-lux-sky
     arguments: []
     needs: null
     loop: null
@@ -164,7 +209,7 @@ flow:
       path: asset/sky/10000_lux.sky
   - annotations: {}
     name: post-process
-    template: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/post-process
+    template: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/post-process
     arguments:
     - annotations: {}
       type: TaskPathArgument
@@ -189,7 +234,7 @@ flow:
       description: null
   - annotations: {}
     name: split-grid
-    template: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/split-grid
+    template: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/split-grid
     arguments:
     - annotations: {}
       type: TaskArgument
@@ -219,7 +264,7 @@ flow:
       name: output-grids-folder
       description: null
       path: output/temp
-digest: a85a19d988a1fdbcf775b1b8e9ed2b26a5af0ab137bbc57b4268729aa6e8a8d5
+digest: 8b959cb7cb3b5f24abd8ac64c03b44c457b318cc9494a7eeca514638edd43e34
 templates:
 - annotations: {}
   inputs: []
@@ -229,7 +274,7 @@ templates:
     name: sky
     description: The resulting sky object
     path: sky.sky
-  name: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/10000-lux-sky
+  name: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/10000-lux-sky
   description: Generates a 10000 lux sky
   command: honeybee radiance sky illuminance 100000
   config:
@@ -248,6 +293,7 @@ templates:
     description: null
     default: null
     spec: null
+    alias: []
     path: model.json
     extensions: null
   - annotations: {}
@@ -256,6 +302,7 @@ templates:
     description: null
     default: null
     spec: null
+    alias: []
     path: sky.sky
     extensions: null
   outputs:
@@ -264,7 +311,7 @@ templates:
     name: scene-file
     description: null
     path: scene.oct
-  name: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/create-octree
+  name: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/create-octree
   description: Generate an octree
   command: honeybee radiance oconv -s sky.sky -m model.json --output scene.oct
   config:
@@ -283,6 +330,7 @@ templates:
     description: null
     default: null
     spec: null
+    alias: []
     path: raw
     extensions: null
   outputs:
@@ -301,7 +349,7 @@ templates:
     name: post-process-folder
     description: null
     path: output
-  name: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/post-process
+  name: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/post-process
   description: Post process your results and $$$
   command: honeybee radiance grid merge raw --folder output
   config:
@@ -320,6 +368,7 @@ templates:
     description: null
     default: null
     spec: null
+    alias: []
     path: grid.pts
     extensions: null
   - annotations: {}
@@ -328,12 +377,14 @@ templates:
     description: a string of radiance parameters
     default: -ab 5
     spec: null
+    alias: []
   - annotations: {}
     type: FunctionFileInput
     name: scene-file
     description: null
     default: null
     spec: null
+    alias: []
     path: scene.oct
     extensions: null
   outputs:
@@ -342,7 +393,7 @@ templates:
     name: result-file
     description: null
     path: grid.res
-  name: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/ray-tracing
+  name: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/ray-tracing
   description: Run ray tracing using some input data!
   command: rtrace -I -h {{inputs.radiance-parameters}} scene.oct < grid.pts > grid.res
   config:
@@ -361,6 +412,7 @@ templates:
     description: The input grid to split
     default: null
     spec: null
+    alias: []
     path: grid.pts
     extensions: null
   - annotations: {}
@@ -369,6 +421,7 @@ templates:
     description: null
     default: null
     spec: null
+    alias: []
   outputs:
   - annotations: {}
     type: FunctionArrayOutput
@@ -381,7 +434,7 @@ templates:
     name: output-grids-folder
     description: null
     path: output
-  name: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/split-grid
+  name: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/split-grid
   description: null
   command: honeybee radiance grid split grid.pts --folder output --log-file output/grids.txt
   config:

--- a/tests/assets/recipes/baked/parametric-daylight-factor.yaml
+++ b/tests/assets/recipes/baked/parametric-daylight-factor.yaml
@@ -34,6 +34,7 @@ flow:
     description: null
     default: []
     spec: null
+    alias: []
     items_type: String
   - annotations: {}
     type: DAGFolderInput
@@ -41,6 +42,7 @@ flow:
     description: A folder full of honeybee models
     default: null
     spec: null
+    alias: []
   outputs:
   - annotations: {}
     type: DAGFolderOutput
@@ -50,12 +52,13 @@ flow:
       annotations: {}
       type: FolderReference
       path: daylight-factor
-  name: 9d5650242b3e73eae0f6d1eb05b629176dcd25b7fecd19ca8ca3b6641d076abc/main
+    alias: []
+  name: 5cbb36fd509b9f6091172ea737f18d2ad96c2af455fa16f42838d207a2c63826/main
   fail_fast: true
   tasks:
   - annotations: {}
     name: daylight-factor
-    template: a85a19d988a1fdbcf775b1b8e9ed2b26a5af0ab137bbc57b4268729aa6e8a8d5/main
+    template: 49c641f701b9985009dbbc9c01961c0422b59909f4e1efb6b389864bba2e916f/main
     arguments:
     - annotations: {}
       type: TaskPathArgument
@@ -93,7 +96,7 @@ flow:
       type: TaskReturn
       name: average
       description: null
-digest: 9d5650242b3e73eae0f6d1eb05b629176dcd25b7fecd19ca8ca3b6641d076abc
+digest: 5cbb36fd509b9f6091172ea737f18d2ad96c2af455fa16f42838d207a2c63826
 templates:
 - annotations: {}
   inputs: []
@@ -103,7 +106,7 @@ templates:
     name: sky
     description: The resulting sky object
     path: sky.sky
-  name: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/10000-lux-sky
+  name: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/10000-lux-sky
   description: Generates a 10000 lux sky
   command: honeybee radiance sky illuminance 100000
   config:
@@ -122,6 +125,7 @@ templates:
     description: null
     default: null
     spec: null
+    alias: []
     path: model.json
     extensions: null
   - annotations: {}
@@ -130,6 +134,7 @@ templates:
     description: null
     default: null
     spec: null
+    alias: []
     path: sky.sky
     extensions: null
   outputs:
@@ -138,7 +143,7 @@ templates:
     name: scene-file
     description: null
     path: scene.oct
-  name: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/create-octree
+  name: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/create-octree
   description: Generate an octree
   command: honeybee radiance oconv -s sky.sky -m model.json --output scene.oct
   config:
@@ -157,6 +162,7 @@ templates:
     description: null
     default: null
     spec: null
+    alias: []
     path: raw
     extensions: null
   outputs:
@@ -175,7 +181,7 @@ templates:
     name: post-process-folder
     description: null
     path: output
-  name: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/post-process
+  name: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/post-process
   description: Post process your results and $$$
   command: honeybee radiance grid merge raw --folder output
   config:
@@ -194,6 +200,7 @@ templates:
     description: null
     default: null
     spec: null
+    alias: []
     path: grid.pts
     extensions: null
   - annotations: {}
@@ -202,12 +209,14 @@ templates:
     description: a string of radiance parameters
     default: -ab 5
     spec: null
+    alias: []
   - annotations: {}
     type: FunctionFileInput
     name: scene-file
     description: null
     default: null
     spec: null
+    alias: []
     path: scene.oct
     extensions: null
   outputs:
@@ -216,7 +225,7 @@ templates:
     name: result-file
     description: null
     path: grid.res
-  name: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/ray-tracing
+  name: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/ray-tracing
   description: Run ray tracing using some input data!
   command: rtrace -I -h {{inputs.radiance-parameters}} scene.oct < grid.pts > grid.res
   config:
@@ -235,6 +244,7 @@ templates:
     description: The input grid to split
     default: null
     spec: null
+    alias: []
     path: grid.pts
     extensions: null
   - annotations: {}
@@ -243,6 +253,7 @@ templates:
     description: null
     default: null
     spec: null
+    alias: []
   outputs:
   - annotations: {}
     type: FunctionArrayOutput
@@ -255,7 +266,7 @@ templates:
     name: output-grids-folder
     description: null
     path: output
-  name: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/split-grid
+  name: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/split-grid
   description: null
   command: honeybee radiance grid split grid.pts --folder output --log-file output/grids.txt
   config:
@@ -274,6 +285,7 @@ templates:
     description: A grid file
     default: null
     spec: null
+    alias: []
     extensions: null
   - annotations: {}
     type: DAGFolderInput
@@ -281,18 +293,21 @@ templates:
     description: A Honeybee model with radiance properties
     default: null
     spec: null
+    alias: []
   - annotations: {}
     type: DAGStringInput
     name: radiance-parameters
     description: The radiance parameters for ray tracing
     default: -I -ab 2 -h
     spec: null
+    alias: []
   - annotations: {}
     type: DAGIntegerInput
     name: sensor-grid-count
     description: The maximum number of grid points per parallel execution
     default: null
     spec: null
+    alias: []
   outputs:
   - annotations: {}
     type: DAGIntegerOutput
@@ -303,6 +318,7 @@ templates:
       type: TaskReference
       name: post-process
       variable: daylight-factor-average
+    alias: []
   - annotations: {}
     type: DAGFolderOutput
     name: data
@@ -312,12 +328,13 @@ templates:
       type: TaskReference
       name: post-process
       variable: post-process-folder
-  name: a85a19d988a1fdbcf775b1b8e9ed2b26a5af0ab137bbc57b4268729aa6e8a8d5/main
+    alias: []
+  name: 49c641f701b9985009dbbc9c01961c0422b59909f4e1efb6b389864bba2e916f/main
   fail_fast: true
   tasks:
   - annotations: {}
     name: create-octree
-    template: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/create-octree
+    template: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/create-octree
     arguments:
     - annotations: {}
       type: TaskPathArgument
@@ -347,7 +364,7 @@ templates:
       path: output/octree/scene.oct
   - annotations: {}
     name: daylight-factor-simulation
-    template: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/ray-tracing
+    template: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/ray-tracing
     arguments:
     - annotations: {}
       type: TaskArgument
@@ -391,7 +408,7 @@ templates:
       path: '{{item.name}}.res'
   - annotations: {}
     name: generate-sky
-    template: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/10000-lux-sky
+    template: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/10000-lux-sky
     arguments: []
     needs: null
     loop: null
@@ -404,7 +421,7 @@ templates:
       path: asset/sky/10000_lux.sky
   - annotations: {}
     name: post-process
-    template: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/post-process
+    template: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/post-process
     arguments:
     - annotations: {}
       type: TaskPathArgument
@@ -429,7 +446,7 @@ templates:
       description: null
   - annotations: {}
     name: split-grid
-    template: 5e6137c2d9a616f75ac9c8162d4de96e272a840109bbd54ba3ff6f4724755ac1/split-grid
+    template: 4a69b1a12f0aee18955ba1c692e4be0e590a89479667d228aa4b8934dc52d4e2/split-grid
     arguments:
     - annotations: {}
       type: TaskArgument

--- a/tests/assets/recipes/folders/daylight-factor/flow/main.yaml
+++ b/tests/assets/recipes/folders/daylight-factor/flow/main.yaml
@@ -9,10 +9,39 @@ inputs:
     annotations: {}
     description: The radiance parameters for ray tracing
     default: -I -ab 2 -h
-  - name: model
-    type: DAGFolderInput
-    annotations: {}
-    description: A Honeybee model with radiance properties
+  - annotations: {}
+    type: DAGFileInput
+    name: model_hbjson
+    description: Honeybee model as a hbjson file.
+    default: null
+    spec: null
+    alias:
+      - type: DAGGenericInputAlias
+        name: model
+        description: |
+            A path to a HBJSON file or a HB model object built with Python or dotnet
+            libraries.
+        platform:
+        - grasshopper
+        handler:
+        - type: IOAliasHandler
+          language: python
+          # this is for clarification purpose only. The module currently doesn't exist.
+          module: honeybee_rhino.handlers
+          function: hb_model_to_hbjson
+        - type: IOAliasHandler
+          language: csharp
+          module: HBRhino.Model
+          function: HBModelToJSON
+      - type: DAGGenericInputAlias
+        name: model
+        platform:
+        - rhino
+        handler:
+        - type: IOAliasHandler
+          language: dotnet
+          module: HBRhino.Model
+          function: ExportRhinoModel
   - name: input-grid
     type: DAGFileInput
     annotations: {}
@@ -56,7 +85,7 @@ tasks:
       type: TaskPathArgument
       from:
         type: InputFolderReference
-        variable: model
+        variable: model_hbjson
     - name: sky
       type: TaskPathArgument
       from:
@@ -119,7 +148,6 @@ tasks:
       path: result
     - name: daylight-factor-average
       type: TaskReturn
-
 
 outputs:
   - name: data

--- a/tests/assets/recipes/valid/daylight-factor.yaml
+++ b/tests/assets/recipes/valid/daylight-factor.yaml
@@ -34,25 +34,68 @@ flow:
     description: A grid file
     default: null
     spec: null
+    alias: []
     extensions: null
   - annotations: {}
-    type: DAGFolderInput
-    name: model
-    description: A Honeybee model with radiance properties
+    type: DAGFileInput
+    name: model_hbjson
+    description: Honeybee model as a hbjson file.
     default: null
     spec: null
+    alias:
+    - annotations: {}
+      type: DAGGenericInputAlias
+      name: model
+      description: 'A path to a HBJSON file or a HB model object built with Python
+        or dotnet
+
+        libraries.
+
+        '
+      default: null
+      spec: null
+      platform:
+      - grasshopper
+      handler:
+      - annotations: {}
+        type: IOAliasHandler
+        language: python
+        module: honeybee_rhino.handlers
+        function: hb_model_to_hbjson
+      - annotations: {}
+        type: IOAliasHandler
+        language: csharp
+        module: HBRhino.Model
+        function: HBModelToJSON
+    - annotations: {}
+      type: DAGGenericInputAlias
+      name: model
+      description: null
+      default: null
+      spec: null
+      platform:
+      - rhino
+      handler:
+      - annotations: {}
+        type: IOAliasHandler
+        language: dotnet
+        module: HBRhino.Model
+        function: ExportRhinoModel
+    extensions: null
   - annotations: {}
     type: DAGStringInput
     name: radiance-parameters
     description: The radiance parameters for ray tracing
     default: -I -ab 2 -h
     spec: null
+    alias: []
   - annotations: {}
     type: DAGIntegerInput
     name: sensor-grid-count
     description: The maximum number of grid points per parallel execution
     default: null
     spec: null
+    alias: []
   outputs:
   - annotations: {}
     type: DAGIntegerOutput
@@ -63,6 +106,7 @@ flow:
       type: TaskReference
       name: post-process
       variable: daylight-factor-average
+    alias: []
   - annotations: {}
     type: DAGFolderOutput
     name: data
@@ -72,6 +116,7 @@ flow:
       type: TaskReference
       name: post-process
       variable: post-process-folder
+    alias: []
   name: main
   fail_fast: true
   tasks:
@@ -85,7 +130,7 @@ flow:
       from:
         annotations: {}
         type: InputFolderReference
-        variable: model
+        variable: model_hbjson
       sub_path: null
     - annotations: {}
       type: TaskPathArgument


### PR DESCRIPTION
This PR adds alias object for inputs and outputs that allows the recipe author to assign pre/post processing for each input/output in different client side applications like Grasshopper, Rhino, etc.

After testing different ideas I ended up adding an alias input/output type for each input/output. This will allow the developers to create a new valid input/output for the target platform with no limitations. The handler will take care of converting the alias input to the original input.
