### PR TITLE
rename DAGObject to DAGJSONObject

### DIFF
--- a/docs.py
+++ b/docs.py
@@ -44,8 +44,9 @@ info = {
 
 
 modules = [
-    {'module': Recipe, 'name': 'Recipe'},
-    {'module': Operator, 'name': 'Operator'}
+    {'module': [Recipe], 'name': 'Recipe'},
+    {'module': [Operator], 'name': 'Operator'},
+    {'module': [Recipe, Operator], 'name': 'Queenbee'}
 ]
 
 
@@ -59,7 +60,7 @@ for module in modules:
     }
 
     openapi = get_openapi(
-        [module['module']],
+        module['module'],
         title=f'Queenbee {module["name"]} Schema',
         description=f'Documentation for Queenbee {module["name"].lower()} schema.',
         version=VERSION, info=info,
@@ -69,7 +70,7 @@ for module in modules:
 
     # with inheritance
     openapi = get_openapi(
-        [module['module']],
+        module['module'],
         title=f'Queenbee {module["name"]} Schema',
         description=f'Documentation for Queenbee {module["name"].lower()} schema.',
         version=VERSION, info=info,
@@ -81,4 +82,4 @@ for module in modules:
 
     # add the mapper file
     with open(f'./docs/{module["name"].lower()}_mapper.json', 'w') as out_file:
-        json.dump(class_mapper([module['module']]), out_file, indent=2)
+        json.dump(class_mapper(module['module']), out_file, indent=2)

--- a/queenbee/io/alias.py
+++ b/queenbee/io/alias.py
@@ -379,7 +379,7 @@ class DAGArrayInputAlias(DAGGenericInputAlias):
             json_schema_validator(value, spec)
 
 
-class DAGObjectInputAlias(DAGGenericInputAlias):
+class DAGJSONObjectInputAlias(DAGGenericInputAlias):
     """An alias JSON object input.
 
     JSON objects are similar to Python dictionaries.
@@ -389,7 +389,7 @@ class DAGObjectInputAlias(DAGGenericInputAlias):
     See http://json-schema.org/understanding-json-schema/reference/object.html for
     more information.
     """
-    type: constr(regex='^DAGObjectInputAlias$') = 'DAGObjectInputAlias'
+    type: constr(regex='^DAGJSONObjectInputAlias$') = 'DAGJSONObjectInputAlias'
 
     default: Dict = Field(
         None,
@@ -414,7 +414,7 @@ class DAGObjectInputAlias(DAGGenericInputAlias):
 DAGAliasInputs = Union[
     DAGGenericInputAlias, DAGStringInputAlias, DAGIntegerInputAlias, DAGNumberInputAlias,
     DAGBooleanInputAlias, DAGFolderInputAlias, DAGFileInputAlias, DAGPathInputAlias,
-    DAGArrayInputAlias, DAGObjectInputAlias
+    DAGArrayInputAlias, DAGJSONObjectInputAlias
 ]
 
 
@@ -553,16 +553,16 @@ class DAGArrayOutputAlias(DAGStringOutputAlias):
     )
 
 
-class DAGObjectOutputAlias(DAGStringOutputAlias):
+class DAGJSONObjectOutputAlias(DAGStringOutputAlias):
     """DAG alias object output.
 
     This output loads the content from a file as a JSON object.
     """
-    type: constr(regex='^DAGObjectOutputAlias$') = 'DAGObjectOutputAlias'
+    type: constr(regex='^DAGJSONObjectOutputAlias$') = 'DAGJSONObjectOutputAlias'
 
 
 DAGAliasOutputs = Union[
     DAGGenericOutputAlias, DAGStringOutputAlias, DAGIntegerOutputAlias,
     DAGNumberOutputAlias, DAGBooleanOutputAlias, DAGFolderOutputAlias,
-    DAGFileOutputAlias, DAGPathOutputAlias, DAGArrayOutputAlias, DAGObjectOutputAlias
+    DAGFileOutputAlias, DAGPathOutputAlias, DAGArrayOutputAlias, DAGJSONObjectOutputAlias
 ]

--- a/queenbee/io/dag.py
+++ b/queenbee/io/dag.py
@@ -329,7 +329,7 @@ class DAGArrayInput(DAGGenericInput):
             json_schema_validator(value, spec)
 
 
-class DAGObjectInput(DAGGenericInput):
+class DAGJSONObjectInput(DAGGenericInput):
     """A JSON object input.
 
     JSON objects are similar to Python dictionaries.
@@ -339,7 +339,7 @@ class DAGObjectInput(DAGGenericInput):
     See http://json-schema.org/understanding-json-schema/reference/object.html for
     more information.
     """
-    type: constr(regex='^DAGObjectInput$') = 'DAGObjectInput'
+    type: constr(regex='^DAGJSONObjectInput$') = 'DAGJSONObjectInput'
 
     default: Dict = Field(
         None,
@@ -363,7 +363,7 @@ class DAGObjectInput(DAGGenericInput):
 
 DAGInputs = Union[
     DAGGenericInput, DAGStringInput, DAGIntegerInput, DAGNumberInput, DAGBooleanInput,
-    DAGFolderInput, DAGFileInput, DAGPathInput, DAGArrayInput, DAGObjectInput
+    DAGFolderInput, DAGFileInput, DAGPathInput, DAGArrayInput, DAGJSONObjectInput
 ]
 
 
@@ -483,16 +483,16 @@ class DAGArrayOutput(DAGStringOutput):
     )
 
 
-class DAGObjectOutput(DAGStringOutput):
+class DAGJSONObjectOutput(DAGStringOutput):
     """DAG object output.
 
     This output loads the content from a file as a JSON object.
     """
-    type: constr(regex='^DAGObjectOutput$') = 'DAGObjectOutput'
+    type: constr(regex='^DAGJSONObjectOutput$') = 'DAGJSONObjectOutput'
 
 
 DAGOutputs = Union[
     DAGGenericOutput, DAGStringOutput, DAGIntegerOutput, DAGNumberOutput,
     DAGBooleanOutput, DAGFolderOutput, DAGFileOutput, DAGPathOutput, DAGArrayOutput,
-    DAGObjectOutput
+    DAGJSONObjectOutput
 ]

--- a/queenbee/io/function.py
+++ b/queenbee/io/function.py
@@ -11,7 +11,7 @@ from jsonschema import validate as json_schema_validator
 
 from .common import PathOutput, ItemType
 from .dag import DAGStringInput, DAGIntegerInput, DAGNumberInput, DAGBooleanInput, \
-    DAGFolderInput, DAGArrayInput, DAGObjectInput
+    DAGFolderInput, DAGArrayInput, DAGJSONObjectInput
 
 
 class FunctionStringInput(DAGStringInput):
@@ -212,7 +212,7 @@ class FunctionArrayInput(DAGArrayInput):
     type: constr(regex='^FunctionArrayInput$') = 'FunctionArrayInput'
 
 
-class FunctionObjectInput(DAGObjectInput):
+class FunctionJSONObjectInput(DAGJSONObjectInput):
     """A JSON object input.
 
     JSON objects are similar to Python dictionaries.
@@ -222,13 +222,13 @@ class FunctionObjectInput(DAGObjectInput):
     See http://json-schema.org/understanding-json-schema/reference/object.html for
     more information.
     """
-    type: constr(regex='^FunctionObjectInput$') = 'FunctionObjectInput'
+    type: constr(regex='^FunctionJSONObjectInput$') = 'FunctionJSONObjectInput'
 
 
 FunctionInputs = Union[
     FunctionStringInput, FunctionIntegerInput, FunctionNumberInput,
     FunctionBooleanInput, FunctionFolderInput, FunctionFileInput, FunctionPathInput,
-    FunctionArrayInput, FunctionObjectInput
+    FunctionArrayInput, FunctionJSONObjectInput
 ]
 
 
@@ -328,16 +328,16 @@ class FunctionArrayOutput(FunctionStringOutput):
     )
 
 
-class FunctionObjectOutput(FunctionStringOutput):
+class FunctionJSONObjectOutput(FunctionStringOutput):
     """Function object output.
 
     This output loads the content from a file as a JSON object.
     """
-    type: constr(regex='^FunctionObjectOutput$') = 'FunctionObjectOutput'
+    type: constr(regex='^FunctionJSONObjectOutput$') = 'FunctionJSONObjectOutput'
 
 
 FunctionOutputs = Union[
     FunctionStringOutput, FunctionIntegerOutput, FunctionNumberOutput,
     FunctionBooleanOutput, FunctionFolderOutput, FunctionFileOutput, FunctionPathOutput,
-    FunctionArrayOutput, FunctionObjectOutput
+    FunctionArrayOutput, FunctionJSONObjectOutput
 ]


### PR DESCRIPTION
This is mainly for clarification purpose. @MingboPeng found it confusing to call this type object considering what object type means in Python and C#.