### PR TITLE
feat(status): add node status i/o primitives

### DIFF
--- a/queenbee/io/inputs/node.py
+++ b/queenbee/io/inputs/node.py
@@ -1,0 +1,144 @@
+"""Queenbee input types for status nodes.
+
+For more information on plugins see plugin module.
+"""
+
+import os
+from typing import Union, List, Dict, Any
+from pydantic import constr, Field
+
+from .function import FunctionStringInput, FunctionIntegerInput, FunctionNumberInput, FunctionBooleanInput, \
+    FunctionFolderInput, FunctionFileInput, FunctionPathInput, FunctionArrayInput, FunctionJSONObjectInput, \
+    FunctionInputs
+
+from .dag import DAGStringInput, DAGIntegerInput, DAGNumberInput, DAGBooleanInput, \
+    DAGFolderInput, DAGFileInput, DAGPathInput, DAGArrayInput, DAGJSONObjectInput, \
+    DAGInputs
+
+from ..artifact_source import HTTP, S3, ProjectFolder
+
+
+class NodeStringInput(FunctionStringInput):
+    """A String input."""
+
+    type: constr(regex='^NodeStringInput$') = 'NodeStringInput'
+
+    value: str
+
+
+class NodeIntegerInput(FunctionIntegerInput):
+    """An integer input."""
+
+    type: constr(regex='^NodeIntegerInput$') = 'NodeIntegerInput'
+
+    value: int
+
+
+class NodeNumberInput(FunctionNumberInput):
+    """A number input."""
+
+    type: constr(regex='^NodeNumberInput$') = 'NodeNumberInput'
+
+    value: float
+
+
+class NodeBooleanInput(FunctionBooleanInput):
+    """The boolean type matches only two special values: True and False."""
+
+    type: constr(regex='^NodeBooleanInput$') = 'NodeBooleanInput'
+
+    value: bool
+
+
+class NodeFolderInput(FunctionFolderInput):
+    """A folder input."""
+    type: constr(regex='^NodeFolderInput$') = 'NodeFolderInput'
+
+    source: Union[HTTP, S3, ProjectFolder] = Field(
+        ...,
+        description='The path to source the file from.'
+    )
+
+class NodeFileInput(FunctionFileInput):
+    """A file input."""
+
+    type: constr(regex='^NodeFileInput$') = 'NodeFileInput'
+
+    source: Union[HTTP, S3, ProjectFolder] = Field(
+        ...,
+        description='The path to source the file from.'
+    )
+
+
+class NodePathInput(FunctionPathInput):
+    """A file or a folder input."""
+
+    type: constr(regex='^NodePathInput$') = 'NodePathInput'
+
+    source: Union[HTTP, S3, ProjectFolder] = Field(
+        ...,
+        description='The path to source the file from.'
+    )
+
+class NodeArrayInput(FunctionArrayInput):
+    """An array input."""
+
+    type: constr(regex='^NodeArrayInput$') = 'NodeArrayInput'
+
+    value: List
+
+
+class NodeJSONObjectInput(FunctionJSONObjectInput):
+    """A JSON object input."""
+
+    type: constr(regex='^NodeJSONObjectInput$') = 'NodeJSONObjectInput'
+
+    value: Dict
+
+NodeInputs = Union[
+    NodeStringInput, NodeIntegerInput, NodeNumberInput,
+    NodeBooleanInput, NodeFolderInput, NodeFileInput, NodePathInput,
+    NodeArrayInput, NodeJSONObjectInput
+]
+
+def from_template(template: Union[DAGInputs, FunctionInputs], value: Any) -> NodeInputs:
+    """Generate a node input from a template input type and a value
+
+    Args:
+        template {Union[DAGInputs, FunctionInputs]} -- An input from a template (DAG or Function)
+        value {Any} -- The input value calculated for this template in the workflow node
+
+    Returns:
+        NodeInputs -- A Node Input object
+    """
+
+    input_dict = template.to_dict()
+    input_dict['value'] = value
+
+    if template.__class__ in [DAGStringInput, FunctionStringInput]:
+        return NodeStringInput.parse_obj(input_dict)
+
+    if template.__class__ in [DAGIntegerInput, FunctionIntegerInput]:
+        return NodeIntegerInput.parse_obj(input_dict)
+    
+    if template.__class__ in [DAGNumberInput, FunctionNumberInput]:
+        return NodeNumberInput.parse_obj(input_dict)
+    
+    if template.__class__ in [DAGBooleanInput, FunctionBooleanInput]:
+        return NodeBooleanInput.parse_obj(input_dict)
+    
+    if template.__class__ in [DAGFolderInput, FunctionFolderInput]:
+        return NodeFolderInput.parse_obj(input_dict)
+    
+    if template.__class__ in [DAGFileInput, FunctionFileInput]:
+        return NodeFileInput.parse_obj(input_dict)
+    
+    if template.__class__ in [DAGPathInput, FunctionPathInput]:
+        return NodePathInput.parse_obj(input_dict)
+    
+    if template.__class__ in [DAGArrayInput, FunctionArrayInput]:
+        return NodeArrayInput.parse_obj(input_dict)
+         
+    if template.__class__ in [DAGJSONObjectInput, FunctionJSONObjectInput]:
+        return NodeJSONObjectInput.parse_obj(input_dict)
+

--- a/queenbee/io/outputs/node.py
+++ b/queenbee/io/outputs/node.py
@@ -1,0 +1,147 @@
+"""Queenbee output types for status nodes.
+
+For more information on plugins see plugin module.
+"""
+
+import os
+from typing import Union, List, Dict, Any
+from pydantic import constr, Field
+
+from .function import FunctionStringOutput, FunctionIntegerOutput, FunctionNumberOutput, FunctionBooleanOutput, \
+    FunctionFolderOutput, FunctionFileOutput, FunctionPathOutput, FunctionArrayOutput, FunctionJSONObjectOutput, \
+    FunctionOutputs
+
+from .dag import DAGStringOutput, DAGIntegerOutput, DAGNumberOutput, DAGBooleanOutput, \
+    DAGFolderOutput, DAGFileOutput, DAGPathOutput, DAGArrayOutput, DAGJSONObjectOutput, \
+    DAGOutputs
+
+from ..artifact_source import HTTP, S3, ProjectFolder
+
+
+class NodeStringOutput(FunctionStringOutput):
+    """A String output."""
+
+    type: constr(regex='^NodeStringOutput$') = 'NodeStringOutput'
+
+    value: str
+
+
+class NodeIntegerOutput(FunctionIntegerOutput):
+    """An integer output."""
+
+    type: constr(regex='^NodeIntegerOutput$') = 'NodeIntegerOutput'
+
+    value: int
+
+
+class NodeNumberOutput(FunctionNumberOutput):
+    """A number output."""
+
+    type: constr(regex='^NodeNumberOutput$') = 'NodeNumberOutput'
+
+    value: float
+
+
+class NodeBooleanOutput(FunctionBooleanOutput):
+    """The boolean type matches only two special values: True and False."""
+
+    type: constr(regex='^NodeBooleanOutput$') = 'NodeBooleanOutput'
+
+    value: bool
+
+
+class NodeFolderOutput(FunctionFolderOutput):
+    """A folder output."""
+    type: constr(regex='^NodeFolderOutput$') = 'NodeFolderOutput'
+
+    source: Union[HTTP, S3, ProjectFolder] = Field(
+        ...,
+        description='The path to source the file from.'
+    )
+
+
+class NodeFileOutput(FunctionFileOutput):
+    """A file output."""
+
+    type: constr(regex='^NodeFileOutput$') = 'NodeFileOutput'
+
+    source: Union[HTTP, S3, ProjectFolder] = Field(
+        ...,
+        description='The path to source the file from.'
+    )
+
+
+class NodePathOutput(FunctionPathOutput):
+    """A file or a folder output."""
+
+    type: constr(regex='^NodePathOutput$') = 'NodePathOutput'
+
+    source: Union[HTTP, S3, ProjectFolder] = Field(
+        ...,
+        description='The path to source the file from.'
+    )
+
+
+class NodeArrayOutput(FunctionArrayOutput):
+    """An array output."""
+
+    type: constr(regex='^NodeArrayOutput$') = 'NodeArrayOutput'
+
+    value: List
+
+
+class NodeJSONObjectOutput(FunctionJSONObjectOutput):
+    """A JSON object output."""
+
+    type: constr(regex='^NodeJSONObjectOutput$') = 'NodeJSONObjectOutput'
+
+    value: Dict
+
+
+NodeOutputs = Union[
+    NodeStringOutput, NodeIntegerOutput, NodeNumberOutput,
+    NodeBooleanOutput, NodeFolderOutput, NodeFileOutput, NodePathOutput,
+    NodeArrayOutput, NodeJSONObjectOutput
+]
+
+def from_template(template: Union[DAGOutputs, FunctionOutputs], value: Any) -> NodeOutputs:
+    """Generate a node output from a template output type and a value
+
+    Args:
+        template {Union[DAGOutputs, FunctionOutputs]} -- An output from a template (DAG or Function)
+        value {Any} -- The output value calculated for this template in the workflow node
+
+    Returns:
+        NodeOutputs -- A Node Output object
+    """
+
+    output_dict = template.to_dict()
+    output_dict['value'] = value
+
+    if template.__class__ in [DAGStringOutput, FunctionStringOutput]:
+        return NodeStringOutput.parse_obj(output_dict)
+
+    if template.__class__ in [DAGIntegerOutput, FunctionIntegerOutput]:
+        return NodeIntegerOutput.parse_obj(output_dict)
+    
+    if template.__class__ in [DAGNumberOutput, FunctionNumberOutput]:
+        return NodeNumberOutput.parse_obj(output_dict)
+    
+    if template.__class__ in [DAGBooleanOutput, FunctionBooleanOutput]:
+        return NodeBooleanOutput.parse_obj(output_dict)
+    
+    if template.__class__ in [DAGFolderOutput, FunctionFolderOutput]:
+        return NodeFolderOutput.parse_obj(output_dict)
+    
+    if template.__class__ in [DAGFileOutput, FunctionFileOutput]:
+        return NodeFileOutput.parse_obj(output_dict)
+    
+    if template.__class__ in [DAGPathOutput, FunctionPathOutput]:
+        return NodePathOutput.parse_obj(output_dict)
+    
+    if template.__class__ in [DAGArrayOutput, FunctionArrayOutput]:
+        return NodeArrayOutput.parse_obj(output_dict)
+         
+    if template.__class__ in [DAGJSONObjectOutput, FunctionJSONObjectOutput]:
+        return NodeJSONObjectOutput.parse_obj(output_dict)
+

--- a/queenbee/workflow/status.py
+++ b/queenbee/workflow/status.py
@@ -8,8 +8,8 @@ from pydantic import Field, constr
 from typing import List, Dict
 
 from ..base.basemodel import BaseModel
-from ..io.inputs.task import TaskArguments
-from ..io.outputs.task import TaskReturns
+from ..io.inputs.node import NodeInputs
+from ..io.outputs.node import NodeOutputs
 
 
 class StatusType(str, Enum):
@@ -19,6 +19,8 @@ class StatusType(str, Enum):
     DAG = 'DAG'
 
     Loop = 'Loop'
+
+    Unknown = 'Unknown'
 
 
 class BaseStatus(BaseModel):
@@ -47,9 +49,9 @@ class BaseStatus(BaseModel):
     )
 
 
-class TaskStatus(BaseStatus):
+class NodeStatus(BaseStatus):
     """The Status of a Workflow Task"""
-    type: constr(regex='^TaskStatus$') = 'TaskStatus'
+    type: constr(regex='^NoneStatus$') = 'NoneStatus'
 
     id: str = Field(
         ...,
@@ -79,12 +81,12 @@ class TaskStatus(BaseStatus):
         description='The command used to run this task. Only applies to Function tasks.'
     )
 
-    inputs: TaskArguments = Field(
+    inputs: NodeInputs = Field(
         ...,
         description='The inputs used by this task'
     )
 
-    outputs: TaskReturns = Field(
+    outputs: NodeOutputs = Field(
         ...,
         description='The outputs produced by this task'
     )


### PR DESCRIPTION
These i/o types are used to link the original template input or output with the value generated by the task/workflow that has been run.